### PR TITLE
bazel: Add two patches

### DIFF
--- a/platforms/BUILD.bazel
+++ b/platforms/BUILD.bazel
@@ -37,3 +37,11 @@ platform(
         "@platforms//cpu:x86_64",
     ],
 )
+
+platform(
+    name = "darwin-arm64",
+    constraint_values = [
+        "@platforms//os:osx",
+        "@platforms//cpu:arm64",
+    ],
+)

--- a/toolchain/BUILD.llvm_repo
+++ b/toolchain/BUILD.llvm_repo
@@ -128,3 +128,239 @@ filegroup(
     name = "symbolizer",
     srcs = ["bin/llvm-symbolizer"],
 )
+
+## LLVM import libraries
+
+cc_import(
+    name = "llvm-import",
+    shared_library = "lib/libLLVM.dylib",
+    visibility = ["//visibility:private"],
+)
+
+# Clang import libraries
+
+cc_import(
+    name = "clangAnalysis-import",
+    static_library = "lib/libclangAnalysis.a",
+    visibility = ["//visibility:private"],
+)
+
+cc_import(
+    name = "clangAnalysisFlowSensitive-import",
+    static_library = "lib/libclangAnalysisFlowSensitive.a",
+    visibility = ["//visibility:private"],
+)
+
+cc_import(
+    name = "clangAST-import",
+    static_library = "lib/libclangAST.a",
+    visibility = ["//visibility:private"],
+)
+
+cc_import(
+    name = "clangASTMatchers-import",
+    static_library = "lib/libclangASTMatchers.a",
+    visibility = ["//visibility:private"],
+)
+
+cc_import(
+    name = "clangBasic-import",
+    static_library = "lib/libclangBasic.a",
+    visibility = ["//visibility:private"],
+)
+
+cc_import(
+    name = "clangEdit-import",
+    static_library = "lib/libclangEdit.a",
+    visibility = ["//visibility:private"],
+)
+
+cc_import(
+    name = "clangDriver-import",
+    static_library = "lib/libclangDriver.a",
+    visibility = ["//visibility:private"],
+)
+
+cc_import(
+    name = "clangFrontend-import",
+    static_library = "lib/libclangFrontend.a",
+    visibility = ["//visibility:private"],
+)
+
+cc_import(
+    name = "clangLex-import",
+    static_library = "lib/libclangLex.a",
+    visibility = ["//visibility:private"],
+)
+
+cc_import(
+    name = "clangParse-import",
+    static_library = "lib/libclangParse.a",
+    visibility = ["//visibility:private"],
+)
+
+cc_import(
+    name = "clangSema-import",
+    static_library = "lib/libclangSema.a",
+    visibility = ["//visibility:private"],
+)
+
+cc_import(
+    name = "clangSerialization-import",
+    static_library = "lib/libclangSerialization.a",
+    visibility = ["//visibility:private"],
+)
+
+cc_import(
+    name = "clangStaticAnalyzerCheckers-import",
+    static_library = "lib/libclangStaticAnalyzerCheckers.a",
+    visibility = ["//visibility:private"],
+)
+
+cc_import(
+    name = "clangStaticAnalyzerCore-import",
+    static_library = "lib/libclangStaticAnalyzerCore.a",
+    visibility = ["//visibility:private"],
+)
+
+cc_import(
+    name = "clangStaticAnalyzerFrontend-import",
+    static_library = "lib/libclangStaticAnalyzerFrontend.a",
+    visibility = ["//visibility:private"],
+)
+
+
+##  LLVM libraries
+
+cc_library(
+    name = "LLVM",
+    hdrs = glob([
+        "include/llvm/**/*",
+        "include/llvm-c/**/*",
+    ]),
+    includes = ["include"],
+    deps = [":llvm-import"],
+)
+
+## Clang libraries
+
+cc_library(
+    name = "clangAnalysis",
+    hdrs = glob(["include/clang/Analysis/**/*"]),
+    includes = ["include"],
+    deps = [":clangAnalysis-import", ":clangAnalysisFlowSensitive-import"],
+)
+
+cc_library(
+    name = "clangAST",
+    hdrs = glob(["include/clang/AST/*"]),
+    includes = ["include"],
+    deps = [":clangAST-import"],
+)
+
+cc_library(
+    name = "clangASTMatchers",
+    hdrs = glob(["include/clang/ASTMatchers/*"]),
+    includes = ["include"],
+    deps = [":clangASTMatchers-import"],
+)
+
+cc_library(
+    name = "clangBasic",
+    hdrs = glob(["include/clang/Basic/*"]),
+    includes = ["include"],
+    deps = [":clangBasic-import"],
+)
+
+cc_library(
+    name = "clangEdit",
+    hdrs = glob(["include/clang/Edit/*"]),
+    includes = ["include"],
+    deps = [":clangEdit-import"],
+)
+
+cc_library(
+    name = "clangDriver",
+    hdrs = glob(["include/clang/Driver/*"]),
+    includes = ["include"],
+    deps = [":clangDriver-import"],
+)
+
+cc_library(
+    name = "clangFrontend",
+    hdrs = glob(["include/clang/Frontend/*"]),
+    includes = ["include"],
+    deps = [":clangFrontend-import"],
+)
+
+cc_library(
+    name = "clangLex",
+    hdrs = glob(["include/clang/Lex/*"]),
+    includes = ["include"],
+    deps = [":clangLex-import"],
+)
+
+cc_library(
+    name = "clangParse",
+    hdrs = glob(["include/clang/Parse/*"]),
+    includes = ["include"],
+    deps = [":clangParse-import"],
+)
+
+cc_library(
+    name = "clangSema",
+    hdrs = glob(["include/clang/Sema/*"]),
+    includes = ["include"],
+    deps = [":clangSema-import"],
+)
+
+cc_library(
+    name = "clangSerialization",
+    hdrs = glob(["include/clang/Serialization/*"]),
+    includes = ["include"],
+    deps = [":clangSerialization-import"],
+)
+
+cc_library(
+    name = "clangStaticAnalyzerCheckers",
+    hdrs = glob(["include/clang/StaticAnalyzer/Checkers/*"]),
+    includes = ["include"],
+    deps = [":clangStaticAnalyzerCheckers-import"],
+)
+
+cc_library(
+    name = "clangStaticAnalyzerCore",
+    hdrs = glob(["include/clang/StaticAnalyzer/Core/*"]),
+    includes = ["include"],
+    deps = [":clangStaticAnalyzerCore-import"],
+)
+
+cc_library(
+    name = "clangStaticAnalyzerFrontend",
+    hdrs = glob(["include/clang/StaticAnalyzerFrontend/*"]),
+    includes = ["include"],
+    deps = [":clangStaticAnalyzerFrontend-import"],
+)
+
+cc_library(
+    name = "libclang",
+    hdrs = glob([
+        "include/clang-c/*",
+    ]),
+    deps = [
+        ":clangAnalysis",
+        ":clangAST",
+        ":clangASTMatchers",
+        ":clangBasic",
+        ":clangEdit",
+        ":clangDriver",
+        ":clangFrontend",
+        ":clangLex",
+        ":clangParse",
+        ":clangSema",
+        ":clangSerialization",
+        ":clangStaticAnalyzerCheckers",
+        ":clangStaticAnalyzerCore",
+        ":clangStaticAnalyzerFrontend",
+    ],
+)

--- a/toolchain/BUILD.toolchain.tpl
+++ b/toolchain/BUILD.toolchain.tpl
@@ -37,6 +37,7 @@ filegroup(
 filegroup(
     name = "internal-use-wrapped-tools",
     srcs = [
+        %{wrapped_clang_tools}
         "bin/cc_wrapper.sh",
         "bin/host_libtool_wrapper.sh",
     ],

--- a/toolchain/cc_toolchain_config.bzl
+++ b/toolchain/cc_toolchain_config.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load(
-    "@bazel_tools//tools/cpp:unix_cc_toolchain_config.bzl",
+    "//toolchain/internal:unix_cc_toolchain_config.bzl",
     unix_cc_toolchain_config = "cc_toolchain_config",
 )
 load(

--- a/toolchain/internal/common.bzl
+++ b/toolchain/internal/common.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SUPPORTED_TARGETS = [("linux", "x86_64"), ("linux", "aarch64"), ("darwin", "x86_64")]
+SUPPORTED_TARGETS = [("linux", "x86_64"), ("linux", "aarch64"), ("darwin", "x86_64"), ("darwin", "arm64")]
 
 host_tool_features = struct(
     SUPPORTS_ARG_FILE = "supports_arg_file",

--- a/toolchain/internal/osx_cc_toolchain_config.bzl
+++ b/toolchain/internal/osx_cc_toolchain_config.bzl
@@ -1,0 +1,2993 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# FIGMA: This file is copied from
+# https://github.com/bazelbuild/bazel/blob/5.2.0/tools/osx/crosstool/cc_toolchain_config.bzl
+#
+# It has some small modifications marked with FIGMA where we try to make it
+# work properly with our compiler instead of the xcode one.
+#
+# FIGMA(cc_wrapper):
+#   This changes the path to cc_wrapper.sh from `cc_wrapper.sh` to
+#   `bin/cc_wrapper.sh`.
+#
+# FIGMA(libtool):
+#   We have to use xcode's libtool, since the one that the open-source LLVM
+#   toolchain (`llvm-libtool-darwin`) has doesn't support some of the flags
+#   here.
+#
+# FIGMA(feature):
+#   We can inject additional flags/environment variables using "features". So
+#   we define our own feature so we can inject some environment variables and
+#   flags we need. See the comment below for more information.
+
+"""A C++ toolchain configuration rule for macOS."""
+
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "action_config",
+    "env_entry",
+    "env_set",
+    "feature",
+    "feature_set",
+    "flag_group",
+    "flag_set",
+    "make_variable",
+    "tool",
+    "tool_path",
+    "variable_with_value",
+    "with_feature_set",
+)
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+
+# The Xcode version from which that has support for deterministic mode
+_SUPPORTS_DETERMINISTIC_MODE = "10.2"
+
+def _compare_versions(dv1, v2):
+    """Return value is <0, 0, >0 depending on DottedVersion dv1 comparison to string v2."""
+    return dv1.compare_to(apple_common.dotted_version(v2))
+
+def _can_use_deterministic_libtool(ctx):
+    """Returns `True` if the current version of `libtool` has support for
+    deterministic mode, and `False` otherwise."""
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+    xcode_version = xcode_config.xcode_version()
+    if _compare_versions(xcode_version, _SUPPORTS_DETERMINISTIC_MODE) >= 0:
+        return True
+    else:
+        return False
+
+def _deterministic_libtool_flags(ctx):
+    """Returns additional `libtool` flags to enable deterministic mode, if they
+    are available."""
+    if _can_use_deterministic_libtool(ctx):
+        return ["-D"]
+    return []
+
+def _target_os_version(ctx):
+    platform_type = ctx.fragments.apple.single_arch_platform.platform_type
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+    return xcode_config.minimum_os_for_platform_type(platform_type)
+
+def _impl(ctx):
+    target_os_version = _target_os_version(ctx)
+
+    if (ctx.attr.cpu == "ios_arm64"):
+        target_system_name = "arm64-apple-ios{}".format(target_os_version)
+    elif (ctx.attr.cpu == "tvos_arm64"):
+        target_system_name = "arm64-apple-tvos{}".format(target_os_version)
+    elif (ctx.attr.cpu == "watchos_arm64_32"):
+        target_system_name = "arm64_32-apple-watchos{}".format(target_os_version)
+    elif (ctx.attr.cpu == "ios_arm64e"):
+        target_system_name = "arm64e-apple-ios{}".format(target_os_version)
+    elif (ctx.attr.cpu == "ios_armv7"):
+        target_system_name = "armv7-apple-ios{}".format(target_os_version)
+    elif (ctx.attr.cpu == "watchos_armv7k"):
+        target_system_name = "armv7k-apple-watchos{}".format(target_os_version)
+    elif (ctx.attr.cpu == "ios_i386"):
+        target_system_name = "i386-apple-ios{}-simulator".format(target_os_version)
+    elif (ctx.attr.cpu == "watchos_i386"):
+        target_system_name = "i386-apple-watchos{}-simulator".format(target_os_version)
+    elif (ctx.attr.cpu == "ios_x86_64"):
+        target_system_name = "x86_64-apple-ios{}-simulator".format(target_os_version)
+    elif (ctx.attr.cpu == "ios_sim_arm64"):
+        target_system_name = "arm64-apple-ios{}-simulator".format(target_os_version)
+    elif (ctx.attr.cpu == "tvos_sim_arm64"):
+        target_system_name = "arm64-apple-tvos{}-simulator".format(target_os_version)
+    elif (ctx.attr.cpu == "watchos_arm64"):
+        target_system_name = "arm64-apple-watchos{}-simulator".format(target_os_version)
+    elif (ctx.attr.cpu == "darwin_x86_64"):
+        target_system_name = "x86_64-apple-macosx{}".format(target_os_version)
+    elif (ctx.attr.cpu == "darwin_arm64"):
+        target_system_name = "arm64-apple-macosx{}".format(target_os_version)
+    elif (ctx.attr.cpu == "darwin_arm64e"):
+        target_system_name = "arm64e-apple-macosx{}".format(target_os_version)
+    elif (ctx.attr.cpu == "tvos_x86_64"):
+        target_system_name = "x86_64-apple-tvos{}-simulator".format(target_os_version)
+    elif (ctx.attr.cpu == "watchos_x86_64"):
+        target_system_name = "x86_64-apple-watchos{}-simulator".format(target_os_version)
+    else:
+        fail("Unreachable")
+
+    if ctx.attr.cpu.startswith("darwin_"):
+        target_libc = "macosx"
+    else:
+        target_libc = ctx.attr.cpu.split("_")[0]
+
+    if ctx.attr.cpu == "darwin_x86_64":
+        abi_libc_version = "darwin_x86_64"
+        abi_version = "darwin_x86_64"
+    else:
+        abi_libc_version = "local"
+        abi_version = "local"
+
+    host_system_name = "x86_64-apple-macosx"
+    arch = ctx.attr.cpu.split("_", 1)[-1]
+    if ctx.attr.cpu in ["ios_sim_arm64", "tvos_sim_arm64", "watchos_arm64"]:
+        arch = "arm64"
+
+    all_compile_actions = [
+        ACTION_NAMES.c_compile,
+        ACTION_NAMES.cpp_compile,
+        ACTION_NAMES.linkstamp_compile,
+        ACTION_NAMES.assemble,
+        ACTION_NAMES.preprocess_assemble,
+        ACTION_NAMES.cpp_header_parsing,
+        ACTION_NAMES.cpp_module_compile,
+        ACTION_NAMES.cpp_module_codegen,
+        ACTION_NAMES.clif_match,
+        ACTION_NAMES.lto_backend,
+    ]
+
+    all_cpp_compile_actions = [
+        ACTION_NAMES.cpp_compile,
+        ACTION_NAMES.linkstamp_compile,
+        ACTION_NAMES.cpp_header_parsing,
+        ACTION_NAMES.cpp_module_compile,
+        ACTION_NAMES.cpp_module_codegen,
+        ACTION_NAMES.clif_match,
+    ]
+
+    preprocessor_compile_actions = [
+        ACTION_NAMES.c_compile,
+        ACTION_NAMES.cpp_compile,
+        ACTION_NAMES.linkstamp_compile,
+        ACTION_NAMES.preprocess_assemble,
+        ACTION_NAMES.cpp_header_parsing,
+        ACTION_NAMES.cpp_module_compile,
+        ACTION_NAMES.clif_match,
+    ]
+
+    codegen_compile_actions = [
+        ACTION_NAMES.c_compile,
+        ACTION_NAMES.cpp_compile,
+        ACTION_NAMES.linkstamp_compile,
+        ACTION_NAMES.assemble,
+        ACTION_NAMES.preprocess_assemble,
+        ACTION_NAMES.cpp_module_codegen,
+        ACTION_NAMES.lto_backend,
+    ]
+
+    all_link_actions = [
+        ACTION_NAMES.cpp_link_executable,
+        ACTION_NAMES.cpp_link_dynamic_library,
+        ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+    ]
+
+    strip_action = action_config(
+        action_name = ACTION_NAMES.strip,
+        flag_sets = [
+            flag_set(
+                flag_groups = [
+                    flag_group(flags = ["-S", "-o", "%{output_file}"]),
+                    flag_group(
+                        flags = ["%{stripopts}"],
+                        iterate_over = "stripopts",
+                    ),
+                    flag_group(flags = ["%{input_file}"]),
+                ],
+            ),
+        ],
+        tools = [tool(path = "/usr/bin/strip")],
+    )
+
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+    xcode_execution_requirements = xcode_config.execution_info().keys()
+
+    cpp_header_parsing_action = action_config(
+        action_name = ACTION_NAMES.cpp_header_parsing,
+        implies = [
+            "preprocessor_defines",
+            "include_system_dirs",
+            "objc_arc",
+            "no_objc_arc",
+            "apple_env",
+            "user_compile_flags",
+            "sysroot",
+            "unfiltered_compile_flags",
+            "compiler_input_flags",
+            "compiler_output_flags",
+            "unfiltered_cxx_flags",
+        ],
+        tools = [
+            tool(
+                path = "wrapped_clang",
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    objc_compile_action = action_config(
+        action_name = ACTION_NAMES.objc_compile,
+        flag_sets = [
+            flag_set(
+                flag_groups = [flag_group(flags = ["-target", target_system_name])],
+            ),
+        ],
+        implies = [
+            "compiler_input_flags",
+            "compiler_output_flags",
+            "objc_actions",
+            "apply_default_compiler_flags",
+            "apply_default_warnings",
+            "framework_paths",
+            "preprocessor_defines",
+            "include_system_dirs",
+            "objc_arc",
+            "no_objc_arc",
+            "apple_env",
+            "user_compile_flags",
+            "sysroot",
+            "unfiltered_compile_flags",
+            "apply_simulator_compiler_flags",
+        ],
+        tools = [
+            tool(
+                path = "wrapped_clang",
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    objcpp_executable_action = action_config(
+        action_name = "objc++-executable",
+        flag_sets = [
+            flag_set(
+                flag_groups = [
+                    flag_group(flags = ["-stdlib=libc++", "-std=gnu++11"]),
+                    flag_group(flags = ["-target", target_system_name]),
+                    flag_group(
+                        flags = [
+                            "-Xlinker",
+                            "-objc_abi_version",
+                            "-Xlinker",
+                            "2",
+                            "-fobjc-link-runtime",
+                            "-ObjC",
+                        ],
+                    ),
+                    flag_group(
+                        flags = ["-framework", "%{framework_names}"],
+                        iterate_over = "framework_names",
+                    ),
+                    flag_group(
+                        flags = ["-weak_framework", "%{weak_framework_names}"],
+                        iterate_over = "weak_framework_names",
+                    ),
+                    flag_group(
+                        flags = ["-l%{library_names}"],
+                        iterate_over = "library_names",
+                    ),
+                    flag_group(flags = ["-filelist", "%{filelist}"]),
+                    flag_group(flags = ["-o", "%{linked_binary}"]),
+                    flag_group(
+                        flags = ["-force_load", "%{force_load_exec_paths}"],
+                        iterate_over = "force_load_exec_paths",
+                    ),
+                    flag_group(
+                        flags = ["%{dep_linkopts}"],
+                        iterate_over = "dep_linkopts",
+                    ),
+                    flag_group(
+                        flags = ["-Wl,%{attr_linkopts}"],
+                        iterate_over = "attr_linkopts",
+                    ),
+                ],
+            ),
+        ],
+        implies = [
+            "include_system_dirs",
+            "framework_paths",
+            "strip_debug_symbols",
+            "apple_env",
+            "apply_implicit_frameworks",
+        ],
+        tools = [
+            tool(
+                path = "wrapped_clang_pp",
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    cpp_link_dynamic_library_action = action_config(
+        action_name = ACTION_NAMES.cpp_link_dynamic_library,
+        implies = [
+            "contains_objc_source",
+            "has_configured_linker_path",
+            "symbol_counts",
+            "shared_flag",
+            "linkstamps",
+            "output_execpath_flags",
+            "runtime_root_flags",
+            "input_param_flags",
+            "strip_debug_symbols",
+            "linker_param_file",
+            "apple_env",
+            "sysroot",
+            "cpp_linker_flags",
+        ],
+        tools = [
+            tool(
+                path = "bin/cc_wrapper.sh", # FIGMA(cc_wrapper)
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    cpp_link_static_library_action = action_config(
+        action_name = ACTION_NAMES.cpp_link_static_library,
+        implies = [
+            "runtime_root_flags",
+            "archiver_flags",
+            "input_param_flags",
+            "linker_param_file",
+            "apple_env",
+        ],
+        tools = [
+            tool(
+                path = "/usr/bin/libtool", # FIGMA(libtool)
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    c_compile_action = action_config(
+        action_name = ACTION_NAMES.c_compile,
+        implies = [
+            "preprocessor_defines",
+            "include_system_dirs",
+            "objc_arc",
+            "no_objc_arc",
+            "apple_env",
+            "user_compile_flags",
+            "sysroot",
+            "unfiltered_compile_flags",
+            "compiler_input_flags",
+            "compiler_output_flags",
+            "unfiltered_cxx_flags",
+        ],
+        tools = [
+            tool(
+                path = "wrapped_clang",
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    cpp_compile_action = action_config(
+        action_name = ACTION_NAMES.cpp_compile,
+        implies = [
+            "preprocessor_defines",
+            "include_system_dirs",
+            "objc_arc",
+            "no_objc_arc",
+            "apple_env",
+            "user_compile_flags",
+            "sysroot",
+            "unfiltered_compile_flags",
+            "compiler_input_flags",
+            "compiler_output_flags",
+            "unfiltered_cxx_flags",
+        ],
+        tools = [
+            tool(
+                path = "wrapped_clang_pp",
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    objcpp_compile_action = action_config(
+        action_name = ACTION_NAMES.objcpp_compile,
+        flag_sets = [
+            flag_set(
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-target",
+                            target_system_name,
+                            "-stdlib=libc++",
+                            "-std=gnu++11",
+                        ],
+                    ),
+                ],
+            ),
+        ],
+        implies = [
+            "compiler_input_flags",
+            "compiler_output_flags",
+            "apply_default_compiler_flags",
+            "apply_default_warnings",
+            "framework_paths",
+            "preprocessor_defines",
+            "include_system_dirs",
+            "objc_arc",
+            "no_objc_arc",
+            "apple_env",
+            "user_compile_flags",
+            "sysroot",
+            "unfiltered_compile_flags",
+            "apply_simulator_compiler_flags",
+        ],
+        tools = [
+            tool(
+                path = "wrapped_clang_pp",
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    assemble_action = action_config(
+        action_name = ACTION_NAMES.assemble,
+        implies = [
+            "objc_arc",
+            "no_objc_arc",
+            "include_system_dirs",
+            "apple_env",
+            "user_compile_flags",
+            "sysroot",
+            "unfiltered_compile_flags",
+            "compiler_input_flags",
+            "compiler_output_flags",
+            "unfiltered_cxx_flags",
+        ],
+        tools = [
+            tool(
+                path = "wrapped_clang",
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    preprocess_assemble_action = action_config(
+        action_name = ACTION_NAMES.preprocess_assemble,
+        implies = [
+            "preprocessor_defines",
+            "include_system_dirs",
+            "objc_arc",
+            "no_objc_arc",
+            "apple_env",
+            "user_compile_flags",
+            "sysroot",
+            "unfiltered_compile_flags",
+            "compiler_input_flags",
+            "compiler_output_flags",
+            "unfiltered_cxx_flags",
+        ],
+        tools = [
+            tool(
+                path = "wrapped_clang",
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    objc_archive_action = action_config(
+        action_name = "objc-archive",
+        flag_sets = [
+            flag_set(
+                flag_groups = [
+                    flag_group(
+                        flags = _deterministic_libtool_flags(ctx) + [
+                            "-no_warning_for_no_symbols",
+                            "-static",
+                            "-filelist",
+                            "%{obj_list_path}",
+                            "-arch_only",
+                            arch,
+                            "-syslibroot",
+                            "%{sdk_dir}",
+                            "-o",
+                            "%{output_execpath}",
+                        ],
+                    ),
+                ],
+            ),
+        ],
+        implies = ["apple_env"],
+        tools = [
+            tool(
+                path = "/usr/bin/libtool", # FIGMA(libtool)
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    objc_executable_action = action_config(
+        action_name = "objc-executable",
+        flag_sets = [
+            flag_set(
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-Xlinker",
+                            "-objc_abi_version",
+                            "-Xlinker",
+                            "2",
+                            "-fobjc-link-runtime",
+                            "-ObjC",
+                        ],
+                    ),
+                ],
+                with_features = [with_feature_set(not_features = ["kernel_extension"])],
+            ),
+            flag_set(
+                flag_groups = [
+                    flag_group(flags = ["-target", target_system_name]),
+                    flag_group(
+                        flags = ["-framework", "%{framework_names}"],
+                        iterate_over = "framework_names",
+                    ),
+                    flag_group(
+                        flags = ["-weak_framework", "%{weak_framework_names}"],
+                        iterate_over = "weak_framework_names",
+                    ),
+                    flag_group(
+                        flags = ["-l%{library_names}"],
+                        iterate_over = "library_names",
+                    ),
+                    flag_group(flags = ["-filelist", "%{filelist}"]),
+                    flag_group(flags = ["-o", "%{linked_binary}"]),
+                    flag_group(
+                        flags = ["-force_load", "%{force_load_exec_paths}"],
+                        iterate_over = "force_load_exec_paths",
+                    ),
+                    flag_group(
+                        flags = ["%{dep_linkopts}"],
+                        iterate_over = "dep_linkopts",
+                    ),
+                    flag_group(
+                        flags = ["-Wl,%{attr_linkopts}"],
+                        iterate_over = "attr_linkopts",
+                    ),
+                ],
+            ),
+        ],
+        implies = [
+            "include_system_dirs",
+            "framework_paths",
+            "strip_debug_symbols",
+            "apple_env",
+            "apply_implicit_frameworks",
+        ],
+        tools = [
+            tool(
+                path = "wrapped_clang",
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    cpp_link_executable_action = action_config(
+        action_name = ACTION_NAMES.cpp_link_executable,
+        implies = [
+            "contains_objc_source",
+            "symbol_counts",
+            "linkstamps",
+            "output_execpath_flags",
+            "runtime_root_flags",
+            "input_param_flags",
+            "force_pic_flags",
+            "strip_debug_symbols",
+            "linker_param_file",
+            "apple_env",
+            "sysroot",
+            "cpp_linker_flags",
+        ],
+        tools = [
+            tool(
+                path = "bin/cc_wrapper.sh", # FIGMA(cc_wrapper)
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    linkstamp_compile_action = action_config(
+        action_name = ACTION_NAMES.linkstamp_compile,
+        implies = [
+            "preprocessor_defines",
+            "include_system_dirs",
+            "objc_arc",
+            "no_objc_arc",
+            "apple_env",
+            "user_compile_flags",
+            "sysroot",
+            "unfiltered_compile_flags",
+            "compiler_input_flags",
+            "compiler_output_flags",
+        ],
+        tools = [
+            tool(
+                path = "wrapped_clang",
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    cpp_module_compile_action = action_config(
+        action_name = ACTION_NAMES.cpp_module_compile,
+        implies = [
+            "preprocessor_defines",
+            "include_system_dirs",
+            "objc_arc",
+            "no_objc_arc",
+            "apple_env",
+            "user_compile_flags",
+            "sysroot",
+            "unfiltered_compile_flags",
+            "compiler_input_flags",
+            "compiler_output_flags",
+            "unfiltered_cxx_flags",
+        ],
+        tools = [
+            tool(
+                path = "wrapped_clang",
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    cpp_link_nodeps_dynamic_library_action = action_config(
+        action_name = ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+        implies = [
+            "contains_objc_source",
+            "has_configured_linker_path",
+            "symbol_counts",
+            "shared_flag",
+            "linkstamps",
+            "output_execpath_flags",
+            "runtime_root_flags",
+            "input_param_flags",
+            "strip_debug_symbols",
+            "linker_param_file",
+            "apple_env",
+            "sysroot",
+            "cpp_linker_flags",
+        ],
+        tools = [
+            tool(
+                path = "bin/cc_wrapper.sh", # FIGMA(cc_wrapper)
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    objc_fully_link_action = action_config(
+        action_name = "objc-fully-link",
+        flag_sets = [
+            flag_set(
+                flag_groups = [
+                    flag_group(
+                        flags = _deterministic_libtool_flags(ctx) + [
+                            "-no_warning_for_no_symbols",
+                            "-static",
+                            "-arch_only",
+                            arch,
+                            "-syslibroot",
+                            "%{sdk_dir}",
+                            "-o",
+                            "%{fully_linked_archive_path}",
+                        ],
+                    ),
+                    flag_group(
+                        flags = ["%{objc_library_exec_paths}"],
+                        iterate_over = "objc_library_exec_paths",
+                    ),
+                    flag_group(
+                        flags = ["%{cc_library_exec_paths}"],
+                        iterate_over = "cc_library_exec_paths",
+                    ),
+                    flag_group(
+                        flags = ["%{imported_library_exec_paths}"],
+                        iterate_over = "imported_library_exec_paths",
+                    ),
+                ],
+            ),
+        ],
+        implies = ["apple_env"],
+        tools = [
+            tool(
+                path = "/usr/bin/libtool", # FIGMA(libtool)
+                execution_requirements = xcode_execution_requirements,
+            ),
+        ],
+    )
+
+    objcopy_embed_data_action = action_config(
+        action_name = "objcopy_embed_data",
+        enabled = True,
+        tools = [tool(path = "/usr/bin/objcopy")],
+    )
+
+    action_configs = [
+        strip_action,
+        c_compile_action,
+        cpp_compile_action,
+        linkstamp_compile_action,
+        cpp_module_compile_action,
+        cpp_header_parsing_action,
+        objc_compile_action,
+        objcpp_compile_action,
+        assemble_action,
+        preprocess_assemble_action,
+        objc_archive_action,
+        objc_executable_action,
+        objcpp_executable_action,
+        cpp_link_executable_action,
+        cpp_link_dynamic_library_action,
+        cpp_link_nodeps_dynamic_library_action,
+        cpp_link_static_library_action,
+        objc_fully_link_action,
+        objcopy_embed_data_action,
+    ]
+
+    if (ctx.attr.cpu == "ios_arm64" or
+        ctx.attr.cpu == "ios_arm64e" or
+        ctx.attr.cpu == "ios_armv7" or
+        ctx.attr.cpu == "ios_i386" or
+        ctx.attr.cpu == "ios_x86_64" or
+        ctx.attr.cpu == "ios_sim_arm64" or
+        ctx.attr.cpu == "watchos_arm64_32" or
+        ctx.attr.cpu == "watchos_armv7k" or
+        ctx.attr.cpu == "watchos_i386" or
+        ctx.attr.cpu == "watchos_x86_64" or
+        ctx.attr.cpu == "watchos_arm64"):
+        apply_default_compiler_flags_feature = feature(
+            name = "apply_default_compiler_flags",
+            flag_sets = [
+                flag_set(
+                    actions = [ACTION_NAMES.objc_compile, ACTION_NAMES.objcpp_compile],
+                    flag_groups = [flag_group(flags = ["-DOS_IOS", "-fno-autolink"])],
+                ),
+            ],
+        )
+    elif (ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e"):
+        apply_default_compiler_flags_feature = feature(
+            name = "apply_default_compiler_flags",
+            flag_sets = [
+                flag_set(
+                    actions = [ACTION_NAMES.objc_compile, ACTION_NAMES.objcpp_compile],
+                    flag_groups = [flag_group(flags = ["-DOS_MACOSX", "-fno-autolink"])],
+                ),
+            ],
+        )
+    elif (ctx.attr.cpu == "tvos_arm64" or
+          ctx.attr.cpu == "tvos_x86_64" or
+          ctx.attr.cpu == "tvos_sim_arm64"):
+        apply_default_compiler_flags_feature = feature(
+            name = "apply_default_compiler_flags",
+            flag_sets = [
+                flag_set(
+                    actions = [ACTION_NAMES.objc_compile, ACTION_NAMES.objcpp_compile],
+                    flag_groups = [flag_group(flags = ["-DOS_TVOS", "-fno-autolink"])],
+                ),
+            ],
+        )
+    else:
+        apply_default_compiler_flags_feature = None
+
+    dynamic_linking_mode_feature = feature(name = "dynamic_linking_mode")
+
+    compile_all_modules_feature = feature(name = "compile_all_modules")
+
+    runtime_root_flags_feature = feature(
+        name = "runtime_root_flags",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions +
+                          [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-Wl,-rpath,@loader_path/%{runtime_library_search_directories}",
+                        ],
+                        iterate_over = "runtime_library_search_directories",
+                        expand_if_available = "runtime_library_search_directories",
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = all_link_actions +
+                          [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = [
+                    flag_group(
+                        flags = ["%{runtime_root_flags}"],
+                        iterate_over = "runtime_root_flags",
+                        expand_if_available = "runtime_root_flags",
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = all_link_actions +
+                          [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = [
+                    flag_group(
+                        flags = ["%{runtime_root_entries}"],
+                        iterate_over = "runtime_root_entries",
+                        expand_if_available = "runtime_root_entries",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    objc_arc_feature = feature(
+        name = "objc_arc",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-fobjc-arc"],
+                        expand_if_available = "objc_arc",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    unfiltered_cxx_flags_feature = feature(
+        name = "unfiltered_cxx_flags",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-no-canonical-prefixes", "-pthread"]),
+                ],
+            ),
+        ],
+    )
+
+    compiler_input_flags_feature = feature(
+        name = "compiler_input_flags",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-c", "%{source_file}"],
+                        expand_if_available = "source_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    strip_debug_symbols_feature = feature(
+        name = "strip_debug_symbols",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions +
+                          ["objc-executable", "objc++-executable"],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-Wl,-S"],
+                        expand_if_available = "strip_debug_symbols",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    shared_flag_feature = feature(
+        name = "shared_flag",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                ],
+                flag_groups = [flag_group(flags = ["-shared"])],
+            ),
+        ],
+    )
+
+    if (ctx.attr.cpu == "ios_i386" or
+        ctx.attr.cpu == "ios_x86_64" or
+        ctx.attr.cpu == "ios_sim_arm64" or
+        ctx.attr.cpu == "tvos_x86_64" or
+        ctx.attr.cpu == "tvos_sim_arm64" or
+        ctx.attr.cpu == "watchos_i386" or
+        ctx.attr.cpu == "watchos_x86_64" or
+        ctx.attr.cpu == "watchos_arm64"):
+        apply_simulator_compiler_flags_feature = feature(
+            name = "apply_simulator_compiler_flags",
+            flag_sets = [
+                flag_set(
+                    actions = [ACTION_NAMES.objc_compile, ACTION_NAMES.objcpp_compile],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-fexceptions",
+                                "-fasm-blocks",
+                                "-fobjc-abi-version=2",
+                                "-fobjc-legacy-dispatch",
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+    else:
+        apply_simulator_compiler_flags_feature = feature(name = "apply_simulator_compiler_flags")
+
+    supports_pic_feature = feature(name = "supports_pic", enabled = True)
+
+    fastbuild_feature = feature(name = "fastbuild")
+
+    no_legacy_features_feature = feature(name = "no_legacy_features")
+
+    symbol_counts_feature = feature(
+        name = "symbol_counts",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["-Wl,--print-symbol-counts=%{symbol_counts_output}"],
+                        expand_if_available = "symbol_counts_output",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    user_link_flags_feature = feature(
+        name = "user_link_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions +
+                          ["objc-executable", "objc++-executable"],
+                flag_groups = [
+                    flag_group(
+                        flags = ["%{user_link_flags}"],
+                        iterate_over = "user_link_flags",
+                        expand_if_available = "user_link_flags",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    if (ctx.attr.cpu == "ios_arm64" or
+        ctx.attr.cpu == "ios_arm64e" or
+        ctx.attr.cpu == "ios_armv7" or
+        ctx.attr.cpu == "ios_i386" or
+        ctx.attr.cpu == "ios_x86_64" or
+        ctx.attr.cpu == "ios_sim_arm64" or
+        ctx.attr.cpu == "tvos_arm64" or
+        ctx.attr.cpu == "tvos_x86_64" or
+        ctx.attr.cpu == "tvos_sim_arm64" or
+        ctx.attr.cpu == "watchos_arm64_32" or
+        ctx.attr.cpu == "watchos_armv7k" or
+        ctx.attr.cpu == "watchos_i386" or
+        ctx.attr.cpu == "watchos_x86_64" or
+        ctx.attr.cpu == "watchos_arm64"):
+        contains_objc_source_feature = feature(
+            name = "contains_objc_source",
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.cpp_link_dynamic_library,
+                        ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                        ACTION_NAMES.cpp_link_executable,
+                    ],
+                    flag_groups = [flag_group(flags = ["-fobjc-link-runtime"])],
+                ),
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.cpp_link_dynamic_library,
+                        ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                        ACTION_NAMES.cpp_link_executable,
+                    ],
+                    flag_groups = [flag_group(flags = ["-framework", "UIKit"])],
+                ),
+            ],
+        )
+    elif (ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e"):
+        contains_objc_source_feature = feature(
+            name = "contains_objc_source",
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.cpp_link_dynamic_library,
+                        ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                        ACTION_NAMES.cpp_link_executable,
+                    ],
+                    flag_groups = [flag_group(flags = ["-fobjc-link-runtime"])],
+                ),
+            ],
+        )
+    else:
+        contains_objc_source_feature = None
+
+    includes_feature = feature(
+        name = "includes",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                    ACTION_NAMES.clif_match,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-include", "%{includes}"],
+                        iterate_over = "includes",
+                        expand_if_available = "includes",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    gcc_coverage_map_format_feature = feature(
+        name = "gcc_coverage_map_format",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-fprofile-arcs", "-ftest-coverage", "-g"],
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.cpp_link_executable,
+                ],
+                flag_groups = [flag_group(flags = ["--coverage"])],
+            ),
+        ],
+        requires = [feature_set(features = ["coverage"])],
+    )
+
+    if (ctx.attr.cpu == "darwin_x86_64" or
+        ctx.attr.cpu == "darwin_arm64" or
+        ctx.attr.cpu == "darwin_arm64e"):
+        default_link_flags_feature = feature(
+            name = "default_link_flags",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = all_link_actions +
+                              ["objc-executable", "objc++-executable"],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-no-canonical-prefixes",
+                                "-target",
+                                target_system_name,
+                            ],
+                        ),
+                    ],
+                ),
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.cpp_link_dynamic_library,
+                        ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ],
+                    flag_groups = [flag_group(flags = ["-undefined", "dynamic_lookup"])],
+                ),
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.cpp_link_executable,
+                        "objc-executable",
+                        "objc++-executable",
+                    ],
+                    flag_groups = [flag_group(flags = ["-undefined", "dynamic_lookup"])],
+                    with_features = [with_feature_set(features = ["dynamic_linking_mode"])],
+                ),
+            ],
+        )
+    else:
+        default_link_flags_feature = feature(
+            name = "default_link_flags",
+            enabled = True,
+            flag_sets = [
+                flag_set(
+                    actions = all_link_actions +
+                              ["objc-executable", "objc++-executable"],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-no-canonical-prefixes",
+                                "-target",
+                                target_system_name,
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    output_execpath_flags_feature = feature(
+        name = "output_execpath_flags",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["-o", "%{output_execpath}"],
+                        expand_if_available = "output_execpath",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    pic_feature = feature(
+        name = "pic",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.preprocess_assemble,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fPIC"], expand_if_available = "pic"),
+                ],
+            ),
+        ],
+    )
+
+    framework_paths_feature = feature(
+        name = "framework_paths",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-F%{framework_include_paths}"],
+                        iterate_over = "framework_include_paths",
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = [
+                    "objc-executable",
+                    "objc++-executable",
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-F%{framework_paths}"],
+                        iterate_over = "framework_paths",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    compiler_output_flags_feature = feature(
+        name = "compiler_output_flags",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-S"],
+                        expand_if_available = "output_assembly_file",
+                    ),
+                    flag_group(
+                        flags = ["-E"],
+                        expand_if_available = "output_preprocess_file",
+                    ),
+                    flag_group(
+                        flags = ["-o", "%{output_file}"],
+                        expand_if_available = "output_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    opt_feature = feature(name = "opt")
+
+    pch_feature = feature(
+        name = "pch",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-include",
+                            "%{pch_file}",
+                        ],
+                        expand_if_available = "pch_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    coverage_feature = feature(name = "coverage")
+
+    include_system_dirs_feature = feature(
+        name = "include_system_dirs",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                    "objc-executable",
+                    "objc++-executable",
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-isysroot",
+                            "%{sdk_dir}",
+                            "-F%{sdk_framework_dir}",
+                            "-F%{platform_developer_framework_dir}",
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    input_param_flags_feature = feature(
+        name = "input_param_flags",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions +
+                          [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-L%{library_search_directories}"],
+                        iterate_over = "library_search_directories",
+                        expand_if_available = "library_search_directories",
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = all_link_actions +
+                          [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = [
+                    flag_group(
+                        flags = ["%{libopts}"],
+                        iterate_over = "libopts",
+                        expand_if_available = "libopts",
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = all_link_actions +
+                          [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-Wl,-force_load,%{whole_archive_linker_params}"],
+                        iterate_over = "whole_archive_linker_params",
+                        expand_if_available = "whole_archive_linker_params",
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = all_link_actions +
+                          [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = [
+                    flag_group(
+                        flags = ["%{linker_input_params}"],
+                        iterate_over = "linker_input_params",
+                        expand_if_available = "linker_input_params",
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = all_link_actions +
+                          [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "libraries_to_link",
+                        flag_groups = [
+                            flag_group(
+                                iterate_over = "libraries_to_link.object_files",
+                                flag_groups = [
+                                    flag_group(
+                                        flags = ["%{libraries_to_link.object_files}"],
+                                        expand_if_false = "libraries_to_link.is_whole_archive",
+                                    ),
+                                    flag_group(
+                                        flags = ["-Wl,-force_load,%{libraries_to_link.object_files}"],
+                                        expand_if_true = "libraries_to_link.is_whole_archive",
+                                    ),
+                                ],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "object_file_group",
+                                ),
+                            ),
+                            flag_group(
+                                flag_groups = [
+                                    flag_group(
+                                        flags = ["%{libraries_to_link.name}"],
+                                        expand_if_false = "libraries_to_link.is_whole_archive",
+                                    ),
+                                    flag_group(
+                                        flags = ["-Wl,-force_load,%{libraries_to_link.name}"],
+                                        expand_if_true = "libraries_to_link.is_whole_archive",
+                                    ),
+                                ],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "object_file",
+                                ),
+                            ),
+                            flag_group(
+                                flag_groups = [
+                                    flag_group(
+                                        flags = ["%{libraries_to_link.name}"],
+                                        expand_if_false = "libraries_to_link.is_whole_archive",
+                                    ),
+                                    flag_group(
+                                        flags = ["-Wl,-force_load,%{libraries_to_link.name}"],
+                                        expand_if_true = "libraries_to_link.is_whole_archive",
+                                    ),
+                                ],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "interface_library",
+                                ),
+                            ),
+                            flag_group(
+                                flag_groups = [
+                                    flag_group(
+                                        flags = ["%{libraries_to_link.name}"],
+                                        expand_if_false = "libraries_to_link.is_whole_archive",
+                                    ),
+                                    flag_group(
+                                        flags = ["-Wl,-force_load,%{libraries_to_link.name}"],
+                                        expand_if_true = "libraries_to_link.is_whole_archive",
+                                    ),
+                                ],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "static_library",
+                                ),
+                            ),
+                            flag_group(
+                                flag_groups = [
+                                    flag_group(
+                                        flags = ["-l%{libraries_to_link.name}"],
+                                        expand_if_false = "libraries_to_link.is_whole_archive",
+                                    ),
+                                    flag_group(
+                                        flags = ["-Wl,-force_load,-l%{libraries_to_link.name}"],
+                                        expand_if_true = "libraries_to_link.is_whole_archive",
+                                    ),
+                                ],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "dynamic_library",
+                                ),
+                            ),
+                            flag_group(
+                                flag_groups = [
+                                    flag_group(
+                                        flags = ["-l:%{libraries_to_link.name}"],
+                                        expand_if_false = "libraries_to_link.is_whole_archive",
+                                    ),
+                                    flag_group(
+                                        flags = ["-Wl,-force_load,-l:%{libraries_to_link.name}"],
+                                        expand_if_true = "libraries_to_link.is_whole_archive",
+                                    ),
+                                ],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "versioned_dynamic_library",
+                                ),
+                            ),
+                        ],
+                        expand_if_available = "libraries_to_link",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    per_object_debug_info_feature = feature(
+        name = "per_object_debug_info",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-gsplit-dwarf", "-g"],
+                        expand_if_available = "per_object_debug_info_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    lipo_feature = feature(
+        name = "lipo",
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
+                flag_groups = [flag_group(flags = ["-fripa"])],
+            ),
+        ],
+        requires = [
+            feature_set(features = ["autofdo"]),
+            feature_set(features = ["fdo_optimize"]),
+            feature_set(features = ["fdo_instrument"]),
+        ],
+    )
+
+    apple_env_feature = feature(
+        name = "apple_env",
+        env_sets = [
+            env_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                    "objc-archive",
+                    "objc-fully-link",
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.cpp_link_static_library,
+                    "objc-executable",
+                    "objc++-executable",
+                    ACTION_NAMES.linkstamp_compile,
+                ],
+                env_entries = [
+                    env_entry(
+                        key = "XCODE_VERSION_OVERRIDE",
+                        value = "%{xcode_version_override_value}",
+                    ),
+                    env_entry(
+                        key = "APPLE_SDK_VERSION_OVERRIDE",
+                        value = "%{apple_sdk_version_override_value}",
+                    ),
+                    env_entry(
+                        key = "APPLE_SDK_PLATFORM",
+                        value = "%{apple_sdk_platform_value}",
+                    ),
+                    env_entry(
+                        key = "ZERO_AR_DATE",
+                        value = "1",
+                    ),
+                ] + [env_entry(key = key, value = value) for key, value in ctx.attr.extra_env.items()],
+            ),
+        ],
+    )
+
+    if (ctx.attr.cpu == "ios_arm64" or
+        ctx.attr.cpu == "ios_arm64e" or
+        ctx.attr.cpu == "ios_armv7" or
+        ctx.attr.cpu == "ios_i386" or
+        ctx.attr.cpu == "ios_x86_64" or
+        ctx.attr.cpu == "ios_sim_arm64" or
+        ctx.attr.cpu == "tvos_arm64" or
+        ctx.attr.cpu == "tvos_x86_64" or
+        ctx.attr.cpu == "tvos_sim_arm64" or
+        ctx.attr.cpu == "watchos_arm64_32" or
+        ctx.attr.cpu == "watchos_armv7k" or
+        ctx.attr.cpu == "watchos_i386" or
+        ctx.attr.cpu == "watchos_x86_64" or
+        ctx.attr.cpu == "watchos_arm64"):
+        apply_implicit_frameworks_feature = feature(
+            name = "apply_implicit_frameworks",
+            flag_sets = [
+                flag_set(
+                    actions = ["objc-executable", "objc++-executable"],
+                    flag_groups = [
+                        flag_group(
+                            flags = ["-framework", "Foundation", "-framework", "UIKit"],
+                        ),
+                    ],
+                ),
+            ],
+        )
+    elif (ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e"):
+        apply_implicit_frameworks_feature = feature(
+            name = "apply_implicit_frameworks",
+            flag_sets = [
+                flag_set(
+                    actions = ["objc-executable", "objc++-executable"],
+                    flag_groups = [flag_group(flags = ["-framework", "Foundation"])],
+                    with_features = [with_feature_set(not_features = ["kernel_extension"])],
+                ),
+            ],
+        )
+    else:
+        apply_implicit_frameworks_feature = None
+
+    dbg_feature = feature(name = "dbg")
+
+    has_configured_linker_path_feature = feature(name = "has_configured_linker_path")
+
+    random_seed_feature = feature(
+        name = "random_seed",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.cpp_module_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-frandom-seed=%{output_file}"],
+                        expand_if_available = "output_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    llvm_coverage_map_format_feature = feature(
+        name = "llvm_coverage_map_format",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-fprofile-instr-generate", "-fcoverage-mapping", "-g"],
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.cpp_link_executable,
+                    "objc-executable",
+                    "objc++-executable",
+                ],
+                flag_groups = [flag_group(flags = ["-fprofile-instr-generate"])],
+            ),
+        ],
+        requires = [feature_set(features = ["coverage"])],
+    )
+
+    force_pic_flags_feature = feature(
+        name = "force_pic_flags",
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.cpp_link_executable],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-Wl,-pie"],
+                        expand_if_available = "force_pic",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    sysroot_feature = feature(
+        name = "sysroot",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.clif_match,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["--sysroot=%{sysroot}"],
+                        expand_if_available = "sysroot",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    autofdo_feature = feature(
+        name = "autofdo",
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-fauto-profile=%{fdo_profile_path}",
+                            "-fprofile-correction",
+                        ],
+                        expand_if_available = "fdo_profile_path",
+                    ),
+                ],
+            ),
+        ],
+        provides = ["profile"],
+    )
+
+    link_libcpp_feature = feature(
+        name = "link_libc++",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions +
+                          ["objc-executable", "objc++-executable"],
+                flag_groups = [flag_group(flags = ["-lc++"])],
+                with_features = [with_feature_set(not_features = ["kernel_extension"])],
+            ),
+        ],
+    )
+
+    objc_actions_feature = feature(
+        name = "objc_actions",
+        implies = [
+            "objc-compile",
+            "objc++-compile",
+            "objc-fully-link",
+            "objc-archive",
+            "objc-executable",
+            "objc++-executable",
+            "assemble",
+            "preprocess-assemble",
+            "c-compile",
+            "c++-compile",
+            "c++-link-static-library",
+            "c++-link-dynamic-library",
+            "c++-link-nodeps-dynamic-library",
+            "c++-link-executable",
+        ],
+    )
+
+    module_maps_feature = feature(name = "module_maps", enabled = True)
+
+    unfiltered_compile_flags_feature = feature(
+        name = "unfiltered_compile_flags",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.linkstamp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-no-canonical-prefixes",
+                            "-Wno-builtin-macro-redefined",
+                            "-D__DATE__=\"redacted\"",
+                            "-D__TIMESTAMP__=\"redacted\"",
+                            "-D__TIME__=\"redacted\"",
+                            "-target",
+                            target_system_name,
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    linker_param_file_feature = feature(
+        name = "linker_param_file",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions + [
+                    ACTION_NAMES.cpp_link_static_library,
+                    ACTION_NAMES.objc_archive,
+                    ACTION_NAMES.objc_fully_link,
+                    ACTION_NAMES.objc_executable,
+                    ACTION_NAMES.objcpp_executable,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["@%{linker_param_file}"],
+                        expand_if_available = "linker_param_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    relative_ast_path_feature = feature(
+        name = "relative_ast_path",
+        env_sets = [
+            env_set(
+                actions = all_link_actions + [
+                    ACTION_NAMES.objc_executable,
+                    ACTION_NAMES.objcpp_executable,
+                ],
+                env_entries = [
+                    env_entry(
+                        key = "RELATIVE_AST_PATH",
+                        value = "true",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    archiver_flags_feature = feature(
+        name = "archiver_flags",
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = [
+                    flag_group(
+                        flags = _deterministic_libtool_flags(ctx) + [
+                            "-no_warning_for_no_symbols",
+                            "-static",
+                            "-o",
+                            "%{output_execpath}",
+                        ],
+                        expand_if_available = "output_execpath",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    fdo_optimize_feature = feature(
+        name = "fdo_optimize",
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-fprofile-use=%{fdo_profile_path}",
+                            "-Wno-profile-instr-unprofiled",
+                            "-Wno-profile-instr-out-of-date",
+                            "-fprofile-correction",
+                        ],
+                        expand_if_available = "fdo_profile_path",
+                    ),
+                ],
+            ),
+        ],
+        provides = ["profile"],
+    )
+
+    no_objc_arc_feature = feature(
+        name = "no_objc_arc",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-fno-objc-arc"],
+                        expand_if_available = "no_objc_arc",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    cpp_linker_flags_feature = feature(
+        name = "cpp_linker_flags",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-lc++", "-target", target_system_name],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    exclude_private_headers_in_module_maps_feature = feature(name = "exclude_private_headers_in_module_maps")
+
+    debug_prefix_map_pwd_is_dot_feature = feature(
+        name = "debug_prefix_map_pwd_is_dot",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [flag_group(flags = ["DEBUG_PREFIX_MAP_PWD=."])],
+            ),
+        ],
+    )
+
+    remap_xcode_path_feature = feature(
+        name = "remap_xcode_path",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [flag_group(flags = [
+                    "-fdebug-prefix-map=__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR",
+                ])],
+            ),
+        ],
+    )
+
+    linkstamps_feature = feature(
+        name = "linkstamps",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["%{linkstamp_paths}"],
+                        iterate_over = "linkstamp_paths",
+                        expand_if_available = "linkstamp_paths",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    include_paths_feature = feature(
+        name = "include_paths",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.clif_match,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-iquote", "%{quote_include_paths}"],
+                        iterate_over = "quote_include_paths",
+                    ),
+                    flag_group(
+                        flags = ["-I%{include_paths}"],
+                        iterate_over = "include_paths",
+                    ),
+                    flag_group(
+                        flags = ["-isystem", "%{system_include_paths}"],
+                        iterate_over = "system_include_paths",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    only_doth_headers_in_module_maps_feature = feature(name = "only_doth_headers_in_module_maps")
+
+    default_compile_flags_feature = feature(
+        name = "default_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.lto_backend,
+                    ACTION_NAMES.clif_match,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-D_FORTIFY_SOURCE=1",
+                        ],
+                    ),
+                ],
+                with_features = [with_feature_set(not_features = ["asan"])],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.lto_backend,
+                    ACTION_NAMES.clif_match,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-fstack-protector",
+                            "-fcolor-diagnostics",
+                            "-Wall",
+                            "-Wthread-safety",
+                            "-Wself-assign",
+                            "-fno-omit-frame-pointer",
+                        ],
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.lto_backend,
+                    ACTION_NAMES.clif_match,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [flag_group(flags = ["-O0", "-DDEBUG"])],
+                with_features = [with_feature_set(features = ["fastbuild"])],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.lto_backend,
+                    ACTION_NAMES.clif_match,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-g0",
+                            "-O2",
+                            "-DNDEBUG",
+                            "-DNS_BLOCK_ASSERTIONS=1",
+                        ],
+                    ),
+                ],
+                with_features = [with_feature_set(features = ["opt"])],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.lto_backend,
+                    ACTION_NAMES.clif_match,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [flag_group(flags = ["-g"])],
+                with_features = [with_feature_set(features = ["dbg"])],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.lto_backend,
+                    ACTION_NAMES.clif_match,
+                ],
+                flag_groups = [flag_group(flags = ["-std=c++11"])],
+            ),
+        ],
+    )
+
+    objcopy_embed_flags_feature = feature(
+        name = "objcopy_embed_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = ["objcopy_embed_data"],
+                flag_groups = [flag_group(flags = ["-I", "binary"])],
+            ),
+        ],
+    )
+
+    dead_strip_feature = feature(
+        name = "dead_strip",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions +
+                          ["objc-executable", "objc++-executable"],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-dead_strip"],
+                    ),
+                ],
+            ),
+        ],
+        requires = [feature_set(features = ["opt"])],
+    )
+
+    oso_prefix_feature = feature(
+        name = "oso_prefix_is_pwd",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions +
+                          ["objc-executable", "objc++-executable"],
+                flag_groups = [flag_group(flags = ["OSO_PREFIX_MAP_PWD"])],
+            ),
+        ],
+    )
+
+    generate_dsym_file_feature = feature(
+        name = "generate_dsym_file",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                    "objc-executable",
+                    "objc++-executable",
+                ],
+                flag_groups = [flag_group(flags = ["-g"])],
+            ),
+            flag_set(
+                actions = ["objc-executable", "objc++-executable"],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "DSYM_HINT_LINKED_BINARY=%{linked_binary}",
+                            "DSYM_HINT_DSYM_PATH=%{dsym_path}",
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    # Kernel extensions for Apple Silicon are arm64e.
+    if (ctx.attr.cpu == "darwin_x86_64" or
+        ctx.attr.cpu == "darwin_arm64e"):
+        kernel_extension_feature = feature(
+            name = "kernel_extension",
+            flag_sets = [
+                flag_set(
+                    actions = ["objc-executable", "objc++-executable"],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-nostdlib",
+                                "-lkmod",
+                                "-lkmodc++",
+                                "-lcc_kext",
+                                "-Xlinker",
+                                "-kext",
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+    else:
+        kernel_extension_feature = feature(name = "kernel_extension")
+
+    apply_default_warnings_feature = feature(
+        name = "apply_default_warnings",
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.objc_compile, ACTION_NAMES.objcpp_compile],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-Wshorten-64-to-32",
+                            "-Wbool-conversion",
+                            "-Wconstant-conversion",
+                            "-Wduplicate-method-match",
+                            "-Wempty-body",
+                            "-Wenum-conversion",
+                            "-Wint-conversion",
+                            "-Wunreachable-code",
+                            "-Wmismatched-return-types",
+                            "-Wundeclared-selector",
+                            "-Wuninitialized",
+                            "-Wunused-function",
+                            "-Wunused-variable",
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    dependency_file_feature = feature(
+        name = "dependency_file",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-MD", "-MF", "%{dependency_file}"],
+                        expand_if_available = "dependency_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    serialized_diagnostics_file_feature = feature(
+        name = "serialized_diagnostics_file",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["--serialize-diagnostics", "%{serialized_diagnostics_file}"],
+                        expand_if_available = "serialized_diagnostics_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    preprocessor_defines_feature = feature(
+        name = "preprocessor_defines",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-D%{preprocessor_defines}"],
+                        iterate_over = "preprocessor_defines",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    fdo_instrument_feature = feature(
+        name = "fdo_instrument",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.cpp_link_executable,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-fprofile-generate=%{fdo_instrument_path}",
+                            "-fno-data-sections",
+                        ],
+                        expand_if_available = "fdo_instrument_path",
+                    ),
+                ],
+            ),
+        ],
+        provides = ["profile"],
+    )
+
+    if (ctx.attr.cpu == "darwin_x86_64" or
+        ctx.attr.cpu == "darwin_arm64" or
+        ctx.attr.cpu == "darwin_arm64e"):
+        link_cocoa_feature = feature(
+            name = "link_cocoa",
+            flag_sets = [
+                flag_set(
+                    actions = ["objc-executable", "objc++-executable"],
+                    flag_groups = [flag_group(flags = ["-framework", "Cocoa"])],
+                ),
+            ],
+        )
+    else:
+        link_cocoa_feature = feature(name = "link_cocoa")
+
+    user_compile_flags_feature = feature(
+        name = "user_compile_flags",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["%{user_compile_flags}"],
+                        iterate_over = "user_compile_flags",
+                        expand_if_available = "user_compile_flags",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    headerpad_feature = feature(
+        name = "headerpad",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions + [
+                    ACTION_NAMES.objc_executable,
+                    ACTION_NAMES.objcpp_executable,
+                ],
+                flag_groups = [flag_group(flags = ["-headerpad_max_install_names"])],
+                with_features = [with_feature_set(not_features = [
+                    "bitcode_embedded",
+                    "bitcode_embedded_markers",
+                ])],
+            ),
+        ],
+    )
+
+    if (ctx.attr.cpu == "ios_arm64" or
+        ctx.attr.cpu == "ios_arm64e" or
+        ctx.attr.cpu == "ios_armv7" or
+        ctx.attr.cpu == "tvos_arm64" or
+        ctx.attr.cpu == "watchos_arm64_32" or
+        ctx.attr.cpu == "watchos_armv7k" or
+        ctx.attr.cpu == "darwin_x86_64" or
+        ctx.attr.cpu == "darwin_arm64" or
+        ctx.attr.cpu == "darwin_arm64e"):
+        bitcode_embedded_feature = feature(
+            name = "bitcode_embedded",
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.objc_compile,
+                        ACTION_NAMES.objcpp_compile,
+                    ],
+                    flag_groups = [flag_group(flags = ["-fembed-bitcode"])],
+                ),
+                flag_set(
+                    actions = all_link_actions + [
+                        ACTION_NAMES.objc_executable,
+                        ACTION_NAMES.objcpp_executable,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-fembed-bitcode",
+                                "-Xlinker",
+                                "-bitcode_verify",
+                                "-Xlinker",
+                                "-bitcode_hide_symbols",
+                                "-Xlinker",
+                                "-bitcode_symbol_map",
+                                "-Xlinker",
+                                "%{bitcode_symbol_map_path}",
+                            ],
+                            expand_if_available = "bitcode_symbol_map_path",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        bitcode_embedded_markers_feature = feature(
+            name = "bitcode_embedded_markers",
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.objc_compile,
+                        ACTION_NAMES.objcpp_compile,
+                    ],
+                    flag_groups = [flag_group(flags = ["-fembed-bitcode-marker"])],
+                ),
+                flag_set(
+                    actions = all_link_actions + [
+                        ACTION_NAMES.objc_executable,
+                        ACTION_NAMES.objcpp_executable,
+                    ],
+                    flag_groups = [flag_group(flags = ["-fembed-bitcode-marker"])],
+                ),
+            ],
+        )
+    else:
+        bitcode_embedded_markers_feature = feature(name = "bitcode_embedded_markers")
+        bitcode_embedded_feature = feature(name = "bitcode_embedded")
+
+    generate_linkmap_feature = feature(
+        name = "generate_linkmap",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.objc_executable,
+                    ACTION_NAMES.objcpp_executable,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-Xlinker",
+                            "-map",
+                            "-Xlinker",
+                            "%{linkmap_exec_path}",
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    set_install_name = feature(
+        name = "set_install_name",
+        enabled = ctx.fragments.cpp.do_not_use_macos_set_install_name,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-Wl,-install_name,@rpath/%{runtime_solib_name}",
+                        ],
+                        expand_if_available = "runtime_solib_name",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    asan_feature = feature(
+        name = "asan",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=address"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["asan"]),
+                ],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.objc_executable,
+                    ACTION_NAMES.objcpp_executable,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=address"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["asan"]),
+                ],
+            ),
+        ],
+    )
+
+    tsan_feature = feature(
+        name = "tsan",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=thread"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["tsan"]),
+                ],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.objc_executable,
+                    ACTION_NAMES.objcpp_executable,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=thread"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["tsan"]),
+                ],
+            ),
+        ],
+    )
+
+    ubsan_feature = feature(
+        name = "ubsan",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=undefined"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["ubsan"]),
+                ],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.objc_executable,
+                    ACTION_NAMES.objcpp_executable,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=undefined"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["ubsan"]),
+                ],
+            ),
+        ],
+    )
+
+    default_sanitizer_flags_feature = feature(
+        name = "default_sanitizer_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-O1",
+                            "-gline-tables-only",
+                            "-fno-omit-frame-pointer",
+                            "-fno-sanitize-recover=all",
+                        ],
+                    ),
+                ],
+                with_features = [
+                    with_feature_set(features = ["asan"]),
+                    with_feature_set(features = ["tsan"]),
+                    with_feature_set(features = ["ubsan"]),
+                ],
+            ),
+        ],
+    )
+
+    # FIGMA(feature): Build up a list of built-in include paths. These are
+    # automatically included by the compiler, but bazel doesn't know about them
+    # so it errors out if you try to include them. We can work around this by
+    # including these directories explicitly.
+    isystem_flags = []
+    for path in ctx.attr.compiler_include_directories:
+        isystem_flags.extend(['-isystem', path])
+
+    figma_feature = feature(
+        name = "figma",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = isystem_flags,
+                    )
+                ],
+            )
+        ],
+	# FIGMA: all compilation steps use the `wrapped_clang` and
+	# `wrapped_clang_pp` executables. We want these wrappers to forward to
+	# our compiler, so we include them as environment variables.
+        env_sets = [
+            env_set(
+                actions = all_compile_actions + all_link_actions + [
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                    ACTION_NAMES.objc_executable,
+                    ACTION_NAMES.objcpp_executable,
+                ],
+                env_entries = [
+                    env_entry(
+                        key = "CLANG_PATH",
+                        value = ctx.attr.clang_path,
+                    ),
+                    env_entry(
+                        key = "CLANG_PP_PATH",
+                        value = ctx.attr.clang_pp_path,
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    if (ctx.attr.cpu == "ios_arm64" or
+        ctx.attr.cpu == "ios_arm64e" or
+        ctx.attr.cpu == "ios_armv7" or
+        ctx.attr.cpu == "ios_i386" or
+        ctx.attr.cpu == "ios_x86_64" or
+        ctx.attr.cpu == "ios_sim_arm64" or
+        ctx.attr.cpu == "tvos_arm64" or
+        ctx.attr.cpu == "tvos_x86_64" or
+        ctx.attr.cpu == "tvos_sim_arm64" or
+        ctx.attr.cpu == "watchos_arm64_32" or
+        ctx.attr.cpu == "watchos_armv7k" or
+        ctx.attr.cpu == "watchos_i386" or
+        ctx.attr.cpu == "watchos_x86_64" or
+        ctx.attr.cpu == "watchos_arm64"):
+        features = [
+            fastbuild_feature,
+            no_legacy_features_feature,
+            opt_feature,
+            dbg_feature,
+            link_libcpp_feature,
+            compile_all_modules_feature,
+            exclude_private_headers_in_module_maps_feature,
+            has_configured_linker_path_feature,
+            only_doth_headers_in_module_maps_feature,
+            default_compile_flags_feature,
+            debug_prefix_map_pwd_is_dot_feature,
+            remap_xcode_path_feature,
+            generate_dsym_file_feature,
+            generate_linkmap_feature,
+            oso_prefix_feature,
+            contains_objc_source_feature,
+            objc_actions_feature,
+            strip_debug_symbols_feature,
+            symbol_counts_feature,
+            shared_flag_feature,
+            kernel_extension_feature,
+            linkstamps_feature,
+            output_execpath_flags_feature,
+            archiver_flags_feature,
+            runtime_root_flags_feature,
+            input_param_flags_feature,
+            force_pic_flags_feature,
+            pch_feature,
+            module_maps_feature,
+            apply_default_warnings_feature,
+            includes_feature,
+            include_paths_feature,
+            sysroot_feature,
+            dependency_file_feature,
+            serialized_diagnostics_file_feature,
+            pic_feature,
+            per_object_debug_info_feature,
+            preprocessor_defines_feature,
+            framework_paths_feature,
+            random_seed_feature,
+            fdo_instrument_feature,
+            fdo_optimize_feature,
+            autofdo_feature,
+            lipo_feature,
+            coverage_feature,
+            llvm_coverage_map_format_feature,
+            gcc_coverage_map_format_feature,
+            apply_default_compiler_flags_feature,
+            include_system_dirs_feature,
+            headerpad_feature,
+            bitcode_embedded_feature,
+            bitcode_embedded_markers_feature,
+            objc_arc_feature,
+            no_objc_arc_feature,
+            apple_env_feature,
+            relative_ast_path_feature,
+            user_link_flags_feature,
+            default_link_flags_feature,
+            dead_strip_feature,
+            cpp_linker_flags_feature,
+            apply_implicit_frameworks_feature,
+            link_cocoa_feature,
+            apply_simulator_compiler_flags_feature,
+            unfiltered_cxx_flags_feature,
+            user_compile_flags_feature,
+            unfiltered_compile_flags_feature,
+            linker_param_file_feature,
+            compiler_input_flags_feature,
+            compiler_output_flags_feature,
+            objcopy_embed_flags_feature,
+            set_install_name,
+            asan_feature,
+            tsan_feature,
+            ubsan_feature,
+            default_sanitizer_flags_feature,
+            figma_feature, # FIGMA(feature)
+        ]
+    elif (ctx.attr.cpu == "darwin_x86_64" or
+          ctx.attr.cpu == "darwin_arm64" or
+          ctx.attr.cpu == "darwin_arm64e"):
+        features = [
+            fastbuild_feature,
+            no_legacy_features_feature,
+            opt_feature,
+            dbg_feature,
+            link_libcpp_feature,
+            compile_all_modules_feature,
+            exclude_private_headers_in_module_maps_feature,
+            has_configured_linker_path_feature,
+            only_doth_headers_in_module_maps_feature,
+            default_compile_flags_feature,
+            debug_prefix_map_pwd_is_dot_feature,
+            remap_xcode_path_feature,
+            generate_dsym_file_feature,
+            generate_linkmap_feature,
+            oso_prefix_feature,
+            contains_objc_source_feature,
+            objc_actions_feature,
+            strip_debug_symbols_feature,
+            symbol_counts_feature,
+            shared_flag_feature,
+            kernel_extension_feature,
+            linkstamps_feature,
+            output_execpath_flags_feature,
+            archiver_flags_feature,
+            runtime_root_flags_feature,
+            input_param_flags_feature,
+            force_pic_flags_feature,
+            pch_feature,
+            module_maps_feature,
+            apply_default_warnings_feature,
+            includes_feature,
+            include_paths_feature,
+            sysroot_feature,
+            dependency_file_feature,
+            serialized_diagnostics_file_feature,
+            pic_feature,
+            per_object_debug_info_feature,
+            preprocessor_defines_feature,
+            framework_paths_feature,
+            random_seed_feature,
+            fdo_instrument_feature,
+            fdo_optimize_feature,
+            autofdo_feature,
+            lipo_feature,
+            coverage_feature,
+            llvm_coverage_map_format_feature,
+            gcc_coverage_map_format_feature,
+            apply_default_compiler_flags_feature,
+            include_system_dirs_feature,
+            headerpad_feature,
+            bitcode_embedded_feature,
+            bitcode_embedded_markers_feature,
+            objc_arc_feature,
+            no_objc_arc_feature,
+            apple_env_feature,
+            relative_ast_path_feature,
+            user_link_flags_feature,
+            default_link_flags_feature,
+            dead_strip_feature,
+            cpp_linker_flags_feature,
+            apply_implicit_frameworks_feature,
+            link_cocoa_feature,
+            apply_simulator_compiler_flags_feature,
+            unfiltered_cxx_flags_feature,
+            user_compile_flags_feature,
+            unfiltered_compile_flags_feature,
+            linker_param_file_feature,
+            compiler_input_flags_feature,
+            compiler_output_flags_feature,
+            objcopy_embed_flags_feature,
+            dynamic_linking_mode_feature,
+            set_install_name,
+            asan_feature,
+            tsan_feature,
+            ubsan_feature,
+            default_sanitizer_flags_feature,
+            figma_feature, # FIGMA(feature)
+        ]
+    else:
+        fail("Unreachable")
+
+    artifact_name_patterns = []
+
+    make_variables = [
+        make_variable(
+            name = "STACK_FRAME_UNLIMITED",
+            value = "-Wframe-larger-than=100000000 -Wno-vla",
+        ),
+    ]
+
+    tool_paths = {
+        "ar": "libtool",
+        "compat-ld": "/usr/bin/ld",
+        "cpp": "/usr/bin/cpp",
+        "dwp": "/usr/bin/dwp",
+        "gcov": "/usr/bin/gcov",
+        "ld": "/usr/bin/ld",
+        "nm": "/usr/bin/nm",
+        "objcopy": "/usr/bin/objcopy",
+        "objdump": "/usr/bin/objdump",
+        "strip": "/usr/bin/strip",
+    }
+
+    tool_paths.update(ctx.attr.tool_paths_overrides)
+
+    out = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.write(out, "Fake executable")
+
+    return [
+        cc_common.create_cc_toolchain_config_info(
+            ctx = ctx,
+            features = features,
+            action_configs = action_configs,
+            artifact_name_patterns = artifact_name_patterns,
+            cxx_builtin_include_directories = ctx.attr.cxx_builtin_include_directories,
+            toolchain_identifier = ctx.attr.cpu,
+            host_system_name = host_system_name,
+            target_system_name = target_system_name,
+            target_cpu = ctx.attr.cpu,
+            target_libc = target_libc,
+            compiler = "compiler",
+            abi_version = abi_version,
+            abi_libc_version = abi_libc_version,
+            tool_paths = [tool_path(name = name, path = path) for (name, path) in tool_paths.items()],
+            make_variables = make_variables,
+            builtin_sysroot = ctx.attr.builtin_sysroot,  # FIGMA(sysroot)
+            cc_target_os = "apple",
+        ),
+        DefaultInfo(
+            executable = out,
+        ),
+    ]
+
+cc_toolchain_config = rule(
+    implementation = _impl,
+    attrs = {
+        "cpu": attr.string(mandatory = True),
+        "compiler": attr.string(),
+        "cxx_builtin_include_directories": attr.string_list(),
+        "tool_paths_overrides": attr.string_dict(),
+        "extra_env": attr.string_dict(),
+        "builtin_sysroot": attr.string(),
+        "_xcode_config": attr.label(default = configuration_field(
+            fragment = "apple",
+            name = "xcode_config_label",
+        )),
+        # FIGMA: attributes we've added to pass through from cc_toolchain_config.bzl
+        "clang_path": attr.string(),
+        "clang_pp_path": attr.string(),
+        "compiler_include_directories": attr.string_list(),
+    },
+    provides = [CcToolchainConfigInfo],
+    executable = True,
+    fragments = ["apple", "cpp"],
+)

--- a/toolchain/internal/unix_cc_toolchain_config.bzl
+++ b/toolchain/internal/unix_cc_toolchain_config.bzl
@@ -1227,7 +1227,12 @@ def _impl(ctx):
                     ACTION_NAMES.objcpp_compile,
                 ],
                 flag_groups = [
-                    flag_group(flags = ["-fsanitize=address"]),
+                    flag_group(flags = [
+                        "-fsanitize=address",
+                        # https://github.com/google/sanitizers/issues/1017
+                        "-mllvm",
+                        "-asan-use-private-alias=1",
+                    ]),
                 ],
                 with_features = [
                     with_feature_set(features = ["asan"]),

--- a/toolchain/internal/unix_cc_toolchain_config.bzl
+++ b/toolchain/internal/unix_cc_toolchain_config.bzl
@@ -1,0 +1,1497 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A Starlark cc_toolchain configuration rule"""
+
+load(
+    "@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl",
+    "action_config",
+    "artifact_name_pattern",
+    "feature",
+    "feature_set",
+    "flag_group",
+    "flag_set",
+    "tool",
+    "tool_path",
+    "variable_with_value",
+    "with_feature_set",
+)
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+
+def layering_check_features(compiler):
+    if compiler != "clang":
+        return []
+    return [
+        feature(
+            name = "use_module_maps",
+            requires = [feature_set(features = ["module_maps"])],
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                    ],
+                    flag_groups = [
+                        flag_group(
+                            flags = [
+                                "-fmodule-name=%{module_name}",
+                                "-fmodule-map-file=%{module_map_file}",
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        ),
+
+        # Tell blaze we support module maps in general, so they will be generated
+        # for all c/c++ rules.
+        # Note: not all C++ rules support module maps; thus, do not imply this
+        # feature from other features - instead, require it.
+        feature(name = "module_maps", enabled = True),
+        feature(
+            name = "layering_check",
+            implies = ["use_module_maps"],
+            flag_sets = [
+                flag_set(
+                    actions = [
+                        ACTION_NAMES.c_compile,
+                        ACTION_NAMES.cpp_compile,
+                        ACTION_NAMES.cpp_header_parsing,
+                        ACTION_NAMES.cpp_module_compile,
+                    ],
+                    flag_groups = [
+                        flag_group(flags = [
+                            "-fmodules-strict-decluse",
+                            "-Wprivate-header",
+                        ]),
+                        flag_group(
+                            iterate_over = "dependent_module_map_files",
+                            flags = [
+                                "-fmodule-map-file=%{dependent_module_map_files}",
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        ),
+    ]
+
+all_compile_actions = [
+    ACTION_NAMES.c_compile,
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.assemble,
+    ACTION_NAMES.preprocess_assemble,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.clif_match,
+    ACTION_NAMES.lto_backend,
+]
+
+all_cpp_compile_actions = [
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.clif_match,
+]
+
+preprocessor_compile_actions = [
+    ACTION_NAMES.c_compile,
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.preprocess_assemble,
+    ACTION_NAMES.cpp_header_parsing,
+    ACTION_NAMES.cpp_module_compile,
+    ACTION_NAMES.clif_match,
+]
+
+codegen_compile_actions = [
+    ACTION_NAMES.c_compile,
+    ACTION_NAMES.cpp_compile,
+    ACTION_NAMES.linkstamp_compile,
+    ACTION_NAMES.assemble,
+    ACTION_NAMES.preprocess_assemble,
+    ACTION_NAMES.cpp_module_codegen,
+    ACTION_NAMES.lto_backend,
+]
+
+all_link_actions = [
+    ACTION_NAMES.cpp_link_executable,
+    ACTION_NAMES.cpp_link_dynamic_library,
+    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+]
+
+lto_index_actions = [
+    ACTION_NAMES.lto_index_for_executable,
+    ACTION_NAMES.lto_index_for_dynamic_library,
+    ACTION_NAMES.lto_index_for_nodeps_dynamic_library,
+]
+
+def _impl(ctx):
+    tool_paths = [
+        tool_path(name = name, path = path)
+        for name, path in ctx.attr.tool_paths.items()
+    ]
+    action_configs = []
+
+    llvm_cov_action = action_config(
+        action_name = ACTION_NAMES.llvm_cov,
+        tools = [
+            tool(
+                path = ctx.attr.tool_paths["llvm-cov"],
+            ),
+        ],
+    )
+
+    action_configs.append(llvm_cov_action)
+
+    supports_pic_feature = feature(
+        name = "supports_pic",
+        enabled = True,
+    )
+    supports_start_end_lib_feature = feature(
+        name = "supports_start_end_lib",
+        enabled = True,
+    )
+
+    default_compile_flags_feature = feature(
+        name = "default_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        # Security hardening requires optimization.
+                        # We need to undef it as some distributions now have it enabled by default.
+                        flags = ["-U_FORTIFY_SOURCE"],
+                    ),
+                ],
+                with_features = [
+                    with_feature_set(
+                        not_features = ["thin_lto"],
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = ctx.attr.compile_flags,
+                    ),
+                ] if ctx.attr.compile_flags else []),
+            ),
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = ctx.attr.dbg_compile_flags,
+                    ),
+                ] if ctx.attr.dbg_compile_flags else []),
+                with_features = [with_feature_set(features = ["dbg"])],
+            ),
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = ctx.attr.opt_compile_flags,
+                    ),
+                ] if ctx.attr.opt_compile_flags else []),
+                with_features = [with_feature_set(features = ["opt"])],
+            ),
+            flag_set(
+                actions = all_cpp_compile_actions + [ACTION_NAMES.lto_backend],
+                flag_groups = ([
+                    flag_group(
+                        flags = ctx.attr.cxx_flags,
+                    ),
+                ] if ctx.attr.cxx_flags else []),
+            ),
+        ],
+    )
+
+    default_link_flags_feature = feature(
+        name = "default_link_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions + lto_index_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = ctx.attr.link_flags,
+                    ),
+                ] if ctx.attr.link_flags else []),
+            ),
+            flag_set(
+                actions = all_link_actions + lto_index_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = ctx.attr.opt_link_flags,
+                    ),
+                ] if ctx.attr.opt_link_flags else []),
+                with_features = [with_feature_set(features = ["opt"])],
+            ),
+        ],
+    )
+
+    dbg_feature = feature(name = "dbg")
+
+    opt_feature = feature(name = "opt")
+
+    sysroot_feature = feature(
+        name = "sysroot",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.lto_backend,
+                    ACTION_NAMES.clif_match,
+                ] + all_link_actions + lto_index_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["--sysroot=%{sysroot}"],
+                        expand_if_available = "sysroot",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    fdo_optimize_feature = feature(
+        name = "fdo_optimize",
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-fprofile-use=%{fdo_profile_path}",
+                            "-fprofile-correction",
+                        ],
+                        expand_if_available = "fdo_profile_path",
+                    ),
+                ],
+            ),
+        ],
+        provides = ["profile"],
+    )
+
+    supports_dynamic_linker_feature = feature(name = "supports_dynamic_linker", enabled = True)
+
+    user_compile_flags_feature = feature(
+        name = "user_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["%{user_compile_flags}"],
+                        iterate_over = "user_compile_flags",
+                        expand_if_available = "user_compile_flags",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    unfiltered_compile_flags_feature = feature(
+        name = "unfiltered_compile_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_compile_actions,
+                flag_groups = ([
+                    flag_group(
+                        flags = ctx.attr.unfiltered_compile_flags,
+                    ),
+                ] if ctx.attr.unfiltered_compile_flags else []),
+            ),
+        ],
+    )
+
+    library_search_directories_feature = feature(
+        name = "library_search_directories",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions + lto_index_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["-L%{library_search_directories}"],
+                        iterate_over = "library_search_directories",
+                        expand_if_available = "library_search_directories",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    static_libgcc_feature = feature(
+        name = "static_libgcc",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.lto_index_for_executable,
+                    ACTION_NAMES.lto_index_for_dynamic_library,
+                ],
+                flag_groups = [flag_group(flags = ["-static-libgcc"])],
+                with_features = [
+                    with_feature_set(features = ["static_link_cpp_runtimes"]),
+                ],
+            ),
+        ],
+    )
+
+    pic_feature = feature(
+        name = "pic",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.cpp_module_compile,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fPIC"], expand_if_available = "pic"),
+                ],
+            ),
+        ],
+    )
+
+    per_object_debug_info_feature = feature(
+        name = "per_object_debug_info",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-gsplit-dwarf", "-g"],
+                        expand_if_available = "per_object_debug_info_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    preprocessor_defines_feature = feature(
+        name = "preprocessor_defines",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.clif_match,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-D%{preprocessor_defines}"],
+                        iterate_over = "preprocessor_defines",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    cs_fdo_optimize_feature = feature(
+        name = "cs_fdo_optimize",
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.lto_backend],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-fprofile-use=%{fdo_profile_path}",
+                            "-Wno-profile-instr-unprofiled",
+                            "-Wno-profile-instr-out-of-date",
+                            "-fprofile-correction",
+                        ],
+                        expand_if_available = "fdo_profile_path",
+                    ),
+                ],
+            ),
+        ],
+        provides = ["csprofile"],
+    )
+
+    autofdo_feature = feature(
+        name = "autofdo",
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-fauto-profile=%{fdo_profile_path}",
+                            "-fprofile-correction",
+                        ],
+                        expand_if_available = "fdo_profile_path",
+                    ),
+                ],
+            ),
+        ],
+        provides = ["profile"],
+    )
+
+    runtime_library_search_directories_feature = feature(
+        name = "runtime_library_search_directories",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions + lto_index_actions,
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "runtime_library_search_directories",
+                        flag_groups = [
+                            flag_group(
+                                flags = [
+                                    "-Wl,-rpath,$EXEC_ORIGIN/%{runtime_library_search_directories}",
+                                ],
+                                expand_if_true = "is_cc_test",
+                            ),
+                            flag_group(
+                                flags = [
+                                    "-Wl,-rpath,$ORIGIN/%{runtime_library_search_directories}",
+                                ],
+                                expand_if_false = "is_cc_test",
+                            ),
+                        ],
+                        expand_if_available =
+                            "runtime_library_search_directories",
+                    ),
+                ],
+                with_features = [
+                    with_feature_set(features = ["static_link_cpp_runtimes"]),
+                ],
+            ),
+            flag_set(
+                actions = all_link_actions + lto_index_actions,
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "runtime_library_search_directories",
+                        flag_groups = [
+                            flag_group(
+                                flags = [
+                                    "-Wl,-rpath,$ORIGIN/%{runtime_library_search_directories}",
+                                ],
+                            ),
+                        ],
+                        expand_if_available =
+                            "runtime_library_search_directories",
+                    ),
+                ],
+                with_features = [
+                    with_feature_set(
+                        not_features = ["static_link_cpp_runtimes"],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    fission_support_feature = feature(
+        name = "fission_support",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions + lto_index_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["-Wl,--gdb-index"],
+                        expand_if_available = "is_using_fission",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    shared_flag_feature = feature(
+        name = "shared_flag",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.lto_index_for_dynamic_library,
+                    ACTION_NAMES.lto_index_for_nodeps_dynamic_library,
+                ],
+                flag_groups = [flag_group(flags = ["-shared"])],
+            ),
+        ],
+    )
+
+    random_seed_feature = feature(
+        name = "random_seed",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_codegen,
+                    ACTION_NAMES.cpp_module_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-frandom-seed=%{output_file}"],
+                        expand_if_available = "output_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    includes_feature = feature(
+        name = "includes",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.clif_match,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-include", "%{includes}"],
+                        iterate_over = "includes",
+                        expand_if_available = "includes",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    fdo_instrument_feature = feature(
+        name = "fdo_instrument",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                ] + all_link_actions + lto_index_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-fprofile-generate=%{fdo_instrument_path}",
+                            "-fno-data-sections",
+                        ],
+                        expand_if_available = "fdo_instrument_path",
+                    ),
+                ],
+            ),
+        ],
+        provides = ["profile"],
+    )
+
+    cs_fdo_instrument_feature = feature(
+        name = "cs_fdo_instrument",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.lto_backend,
+                ] + all_link_actions + lto_index_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-fcs-profile-generate=%{cs_fdo_instrument_path}",
+                        ],
+                        expand_if_available = "cs_fdo_instrument_path",
+                    ),
+                ],
+            ),
+        ],
+        provides = ["csprofile"],
+    )
+
+    include_paths_feature = feature(
+        name = "include_paths",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.clif_match,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-iquote", "%{quote_include_paths}"],
+                        iterate_over = "quote_include_paths",
+                    ),
+                    flag_group(
+                        flags = ["-I%{include_paths}"],
+                        iterate_over = "include_paths",
+                    ),
+                    flag_group(
+                        flags = ["-isystem", "%{system_include_paths}"],
+                        iterate_over = "system_include_paths",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    external_include_paths_feature = feature(
+        name = "external_include_paths",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.linkstamp_compile,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.clif_match,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-isystem", "%{external_include_paths}"],
+                        iterate_over = "external_include_paths",
+                        expand_if_available = "external_include_paths",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    symbol_counts_feature = feature(
+        name = "symbol_counts",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions + lto_index_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-Wl,--print-symbol-counts=%{symbol_counts_output}",
+                        ],
+                        expand_if_available = "symbol_counts_output",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    strip_debug_symbols_feature = feature(
+        name = "strip_debug_symbols",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions + lto_index_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["-Wl,-S"],
+                        expand_if_available = "strip_debug_symbols",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    build_interface_libraries_feature = feature(
+        name = "build_interface_libraries",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.lto_index_for_dynamic_library,
+                    ACTION_NAMES.lto_index_for_nodeps_dynamic_library,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "%{generate_interface_library}",
+                            "%{interface_library_builder_path}",
+                            "%{interface_library_input_path}",
+                            "%{interface_library_output_path}",
+                        ],
+                        expand_if_available = "generate_interface_library",
+                    ),
+                ],
+                with_features = [
+                    with_feature_set(
+                        features = ["supports_interface_shared_libraries"],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    libraries_to_link_feature = feature(
+        name = "libraries_to_link",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions + lto_index_actions,
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "libraries_to_link",
+                        flag_groups = [
+                            flag_group(
+                                flags = ["-Wl,--start-lib"],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "object_file_group",
+                                ),
+                            ),
+                            flag_group(
+                                flags = ["-Wl,-whole-archive"],
+                                expand_if_true =
+                                    "libraries_to_link.is_whole_archive",
+                            ),
+                            flag_group(
+                                flags = ["%{libraries_to_link.object_files}"],
+                                iterate_over = "libraries_to_link.object_files",
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "object_file_group",
+                                ),
+                            ),
+                            flag_group(
+                                flags = ["%{libraries_to_link.name}"],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "object_file",
+                                ),
+                            ),
+                            flag_group(
+                                flags = ["%{libraries_to_link.name}"],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "interface_library",
+                                ),
+                            ),
+                            flag_group(
+                                flags = ["%{libraries_to_link.name}"],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "static_library",
+                                ),
+                            ),
+                            flag_group(
+                                flags = ["-l%{libraries_to_link.name}"],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "dynamic_library",
+                                ),
+                            ),
+                            flag_group(
+                                flags = ["-l:%{libraries_to_link.name}"],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "versioned_dynamic_library",
+                                ),
+                            ),
+                            flag_group(
+                                flags = ["-Wl,-no-whole-archive"],
+                                expand_if_true = "libraries_to_link.is_whole_archive",
+                            ),
+                            flag_group(
+                                flags = ["-Wl,--end-lib"],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "object_file_group",
+                                ),
+                            ),
+                        ],
+                        expand_if_available = "libraries_to_link",
+                    ),
+                    flag_group(
+                        flags = ["-Wl,@%{thinlto_param_file}"],
+                        expand_if_true = "thinlto_param_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    user_link_flags_feature = feature(
+        name = "user_link_flags",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions + lto_index_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["%{user_link_flags}"],
+                        iterate_over = "user_link_flags",
+                        expand_if_available = "user_link_flags",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    default_link_libs_feature = feature(
+        name = "default_link_libs",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions + lto_index_actions,
+                flag_groups = [flag_group(flags = ctx.attr.link_libs)] if ctx.attr.link_libs else [],
+            ),
+        ],
+    )
+
+    fdo_prefetch_hints_feature = feature(
+        name = "fdo_prefetch_hints",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.lto_backend,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-mllvm",
+                            "-prefetch-hints-file=%{fdo_prefetch_hints_path}",
+                        ],
+                        expand_if_available = "fdo_prefetch_hints_path",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    linkstamps_feature = feature(
+        name = "linkstamps",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions + lto_index_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["%{linkstamp_paths}"],
+                        iterate_over = "linkstamp_paths",
+                        expand_if_available = "linkstamp_paths",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    archiver_flags_feature = feature(
+        name = "archiver_flags",
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = [
+                    flag_group(flags = ["rcsD"]),
+                    flag_group(
+                        flags = ["%{output_execpath}"],
+                        expand_if_available = "output_execpath",
+                    ),
+                ],
+                with_features = [
+                    with_feature_set(
+                        not_features = ["libtool"],
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = [
+                    flag_group(flags = ["-static", "-s"]),
+                    flag_group(
+                        flags = ["-o", "%{output_execpath}"],
+                        expand_if_available = "output_execpath",
+                    ),
+                ],
+                with_features = [
+                    with_feature_set(
+                        features = ["libtool"],
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = [
+                    flag_group(
+                        iterate_over = "libraries_to_link",
+                        flag_groups = [
+                            flag_group(
+                                flags = ["%{libraries_to_link.name}"],
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "object_file",
+                                ),
+                            ),
+                            flag_group(
+                                flags = ["%{libraries_to_link.object_files}"],
+                                iterate_over = "libraries_to_link.object_files",
+                                expand_if_equal = variable_with_value(
+                                    name = "libraries_to_link.type",
+                                    value = "object_file_group",
+                                ),
+                            ),
+                        ],
+                        expand_if_available = "libraries_to_link",
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = [ACTION_NAMES.cpp_link_static_library],
+                flag_groups = ([
+                    flag_group(
+                        flags = ctx.attr.archive_flags,
+                    ),
+                ] if ctx.attr.archive_flags else []),
+            ),
+        ],
+    )
+
+    force_pic_flags_feature = feature(
+        name = "force_pic_flags",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.lto_index_for_executable,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-pie"],
+                        expand_if_available = "force_pic",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    dependency_file_feature = feature(
+        name = "dependency_file",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.clif_match,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["-MD", "-MF", "%{dependency_file}"],
+                        expand_if_available = "dependency_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    serialized_diagnostics_file_feature = feature(
+        name = "serialized_diagnostics_file",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.assemble,
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_module_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.clif_match,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = ["--serialize-diagnostics", "%{serialized_diagnostics_file}"],
+                        expand_if_available = "serialized_diagnostics_file",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    dynamic_library_linker_tool_feature = feature(
+        name = "dynamic_library_linker_tool",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.lto_index_for_dynamic_library,
+                    ACTION_NAMES.lto_index_for_nodeps_dynamic_library,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [" + cppLinkDynamicLibraryToolPath + "],
+                        expand_if_available = "generate_interface_library",
+                    ),
+                ],
+                with_features = [
+                    with_feature_set(
+                        features = ["supports_interface_shared_libraries"],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    output_execpath_flags_feature = feature(
+        name = "output_execpath_flags",
+        flag_sets = [
+            flag_set(
+                actions = all_link_actions + lto_index_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = ["-o", "%{output_execpath}"],
+                        expand_if_available = "output_execpath",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    # Note that we also set --coverage for c++-link-nodeps-dynamic-library. The
+    # generated code contains references to gcov symbols, and the dynamic linker
+    # can't resolve them unless the library is linked against gcov.
+    coverage_feature = feature(
+        name = "coverage",
+        provides = ["profile"],
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.preprocess_assemble,
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.cpp_header_parsing,
+                    ACTION_NAMES.cpp_module_compile,
+                ],
+                flag_groups = ([
+                    flag_group(flags = ctx.attr.coverage_compile_flags),
+                ] if ctx.attr.coverage_compile_flags else []),
+            ),
+            flag_set(
+                actions = all_link_actions + lto_index_actions,
+                flag_groups = ([
+                    flag_group(flags = ctx.attr.coverage_link_flags),
+                ] if ctx.attr.coverage_link_flags else []),
+            ),
+        ],
+    )
+
+    thinlto_feature = feature(
+        name = "thin_lto",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                ] + all_link_actions + lto_index_actions,
+                flag_groups = [
+                    flag_group(flags = ["-flto=thin"]),
+                    flag_group(
+                        expand_if_available = "lto_indexing_bitcode_file",
+                        flags = [
+                            "-Xclang",
+                            "-fthin-link-bitcode=%{lto_indexing_bitcode_file}",
+                        ],
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = [ACTION_NAMES.linkstamp_compile],
+                flag_groups = [flag_group(flags = ["-DBUILD_LTO_TYPE=thin"])],
+            ),
+            flag_set(
+                actions = lto_index_actions,
+                flag_groups = [
+                    flag_group(flags = [
+                        "-flto=thin",
+                        "-Wl,-plugin-opt,thinlto-index-only%{thinlto_optional_params_file}",
+                        "-Wl,-plugin-opt,thinlto-emit-imports-files",
+                        "-Wl,-plugin-opt,thinlto-prefix-replace=%{thinlto_prefix_replace}",
+                    ]),
+                    flag_group(
+                        expand_if_available = "thinlto_object_suffix_replace",
+                        flags = [
+                            "-Wl,-plugin-opt,thinlto-object-suffix-replace=%{thinlto_object_suffix_replace}",
+                        ],
+                    ),
+                    flag_group(
+                        expand_if_available = "thinlto_merged_object_file",
+                        flags = [
+                            "-Wl,-plugin-opt,obj-path=%{thinlto_merged_object_file}",
+                        ],
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = [ACTION_NAMES.lto_backend],
+                flag_groups = [
+                    flag_group(flags = [
+                        "-c",
+                        "-fthinlto-index=%{thinlto_index}",
+                        "-o",
+                        "%{thinlto_output_object_file}",
+                        "-x",
+                        "ir",
+                        "%{thinlto_input_bitcode_file}",
+                    ]),
+                ],
+            ),
+        ],
+    )
+
+    treat_warnings_as_errors_feature = feature(
+        name = "treat_warnings_as_errors",
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
+                flag_groups = [flag_group(flags = ["-Werror"])],
+            ),
+            flag_set(
+                actions = all_link_actions,
+                flag_groups = [flag_group(flags = ["-Wl,-fatal-warnings"])],
+            ),
+        ],
+    )
+
+    is_linux = ctx.attr.target_libc != "macosx"
+    libtool_feature = feature(
+        name = "libtool",
+        enabled = not is_linux,
+    )
+
+    asan_feature = feature(
+        name = "asan",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=address"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["asan"]),
+                ],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.objc_executable,
+                    ACTION_NAMES.objcpp_executable,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=address"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["asan"]),
+                ],
+            ),
+        ],
+    )
+
+    tsan_feature = feature(
+        name = "tsan",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=thread"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["tsan"]),
+                ],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.objc_executable,
+                    ACTION_NAMES.objcpp_executable,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=thread"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["tsan"]),
+                ],
+            ),
+        ],
+    )
+
+    ubsan_feature = feature(
+        name = "ubsan",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=undefined"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["ubsan"]),
+                ],
+            ),
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_executable,
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                    ACTION_NAMES.objc_executable,
+                    ACTION_NAMES.objcpp_executable,
+                ],
+                flag_groups = [
+                    flag_group(flags = ["-fsanitize=undefined"]),
+                ],
+                with_features = [
+                    with_feature_set(features = ["ubsan"]),
+                ],
+            ),
+        ],
+    )
+
+    default_sanitizer_flags_feature = feature(
+        name = "default_sanitizer_flags",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.c_compile,
+                    ACTION_NAMES.cpp_compile,
+                    ACTION_NAMES.objc_compile,
+                    ACTION_NAMES.objcpp_compile,
+                ],
+                flag_groups = [
+                    flag_group(
+                        flags = [
+                            "-O1",
+                            "-gline-tables-only",
+                            "-fno-omit-frame-pointer",
+                            "-fno-sanitize-recover=all",
+                        ],
+                    ),
+                ],
+                with_features = [
+                    with_feature_set(features = ["asan"]),
+                    with_feature_set(features = ["tsan"]),
+                    with_feature_set(features = ["ubsan"]),
+                ],
+            ),
+        ],
+    )
+
+    # TODO(#8303): Mac crosstool should also declare every feature.
+    if is_linux:
+        # Linux artifact name patterns are the default.
+        artifact_name_patterns = []
+        features = [
+            dependency_file_feature,
+            serialized_diagnostics_file_feature,
+            random_seed_feature,
+            pic_feature,
+            per_object_debug_info_feature,
+            preprocessor_defines_feature,
+            includes_feature,
+            include_paths_feature,
+            external_include_paths_feature,
+            fdo_instrument_feature,
+            cs_fdo_instrument_feature,
+            cs_fdo_optimize_feature,
+            thinlto_feature,
+            fdo_prefetch_hints_feature,
+            autofdo_feature,
+            build_interface_libraries_feature,
+            dynamic_library_linker_tool_feature,
+            symbol_counts_feature,
+            shared_flag_feature,
+            linkstamps_feature,
+            output_execpath_flags_feature,
+            runtime_library_search_directories_feature,
+            library_search_directories_feature,
+            libtool_feature,
+            archiver_flags_feature,
+            force_pic_flags_feature,
+            fission_support_feature,
+            strip_debug_symbols_feature,
+            coverage_feature,
+            supports_pic_feature,
+        ] + (
+            [
+                supports_start_end_lib_feature,
+            ] if ctx.attr.supports_start_end_lib else []
+        ) + [
+            default_compile_flags_feature,
+            default_link_flags_feature,
+            libraries_to_link_feature,
+            user_link_flags_feature,
+            default_link_libs_feature,
+            static_libgcc_feature,
+            fdo_optimize_feature,
+            supports_dynamic_linker_feature,
+            dbg_feature,
+            opt_feature,
+            user_compile_flags_feature,
+            sysroot_feature,
+            unfiltered_compile_flags_feature,
+            treat_warnings_as_errors_feature,
+            asan_feature,
+            tsan_feature,
+            ubsan_feature,
+            default_sanitizer_flags_feature,
+        ] + layering_check_features(ctx.attr.compiler)
+    else:
+        # macOS artifact name patterns differ from the defaults only for dynamic
+        # libraries.
+        artifact_name_patterns = [
+            artifact_name_pattern(
+                category_name = "dynamic_library",
+                prefix = "lib",
+                extension = ".dylib",
+            ),
+        ]
+        features = [
+            libtool_feature,
+            archiver_flags_feature,
+            supports_pic_feature,
+        ] + (
+            [
+                supports_start_end_lib_feature,
+            ] if ctx.attr.supports_start_end_lib else []
+        ) + [
+            coverage_feature,
+            default_compile_flags_feature,
+            default_link_flags_feature,
+            user_link_flags_feature,
+            default_link_libs_feature,
+            fdo_optimize_feature,
+            supports_dynamic_linker_feature,
+            dbg_feature,
+            opt_feature,
+            user_compile_flags_feature,
+            sysroot_feature,
+            unfiltered_compile_flags_feature,
+            treat_warnings_as_errors_feature,
+            asan_feature,
+            tsan_feature,
+            ubsan_feature,
+            default_sanitizer_flags_feature,
+        ] + layering_check_features(ctx.attr.compiler)
+
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx,
+        features = features,
+        action_configs = action_configs,
+        artifact_name_patterns = artifact_name_patterns,
+        cxx_builtin_include_directories = ctx.attr.cxx_builtin_include_directories,
+        toolchain_identifier = ctx.attr.toolchain_identifier,
+        host_system_name = ctx.attr.host_system_name,
+        target_system_name = ctx.attr.target_system_name,
+        target_cpu = ctx.attr.cpu,
+        target_libc = ctx.attr.target_libc,
+        compiler = ctx.attr.compiler,
+        abi_version = ctx.attr.abi_version,
+        abi_libc_version = ctx.attr.abi_libc_version,
+        tool_paths = tool_paths,
+        builtin_sysroot = ctx.attr.builtin_sysroot,
+    )
+
+cc_toolchain_config = rule(
+    implementation = _impl,
+    attrs = {
+        "cpu": attr.string(mandatory = True),
+        "compiler": attr.string(mandatory = True),
+        "toolchain_identifier": attr.string(mandatory = True),
+        "host_system_name": attr.string(mandatory = True),
+        "target_system_name": attr.string(mandatory = True),
+        "target_libc": attr.string(mandatory = True),
+        "abi_version": attr.string(mandatory = True),
+        "abi_libc_version": attr.string(mandatory = True),
+        "cxx_builtin_include_directories": attr.string_list(),
+        "tool_paths": attr.string_dict(),
+        "compile_flags": attr.string_list(),
+        "dbg_compile_flags": attr.string_list(),
+        "opt_compile_flags": attr.string_list(),
+        "cxx_flags": attr.string_list(),
+        "link_flags": attr.string_list(),
+        "archive_flags": attr.string_list(),
+        "link_libs": attr.string_list(),
+        "opt_link_flags": attr.string_list(),
+        "unfiltered_compile_flags": attr.string_list(),
+        "coverage_compile_flags": attr.string_list(),
+        "coverage_link_flags": attr.string_list(),
+        "supports_start_end_lib": attr.bool(),
+        "builtin_sysroot": attr.string(),
+    },
+    provides = [CcToolchainConfigInfo],
+)

--- a/toolchain/osx_cc_wrapper.sh.tpl
+++ b/toolchain/osx_cc_wrapper.sh.tpl
@@ -83,8 +83,11 @@ if [[ ":${PATH}:" != *":/usr/bin:"* ]]; then
 fi
 
 # Call the C++ compiler.
-if [[ -f %{toolchain_path_prefix}bin/clang ]]; then
-  %{toolchain_path_prefix}bin/clang "$@"
+# FIGMA: Use `wrapped_clang` instead of `bin/clang` to handle the various apple
+# configurations required to build.
+PARENT_DIR="${BASH_SOURCE[0]%/*/*}"
+if [[ -f "${PARENT_DIR}"/wrapped_clang ]]; then
+  "${PARENT_DIR}"/wrapped_clang "$@"
 elif [[ "${BASH_SOURCE[0]}" == "/"* ]]; then
   # Some consumers of `CcToolchainConfigInfo` (e.g. `cmake` from rules_foreign_cc)
   # change CWD and call $CC (this script) with its absolute path.

--- a/toolchain/wrapped_clang.cc
+++ b/toolchain/wrapped_clang.cc
@@ -1,0 +1,437 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// wrapped_clang.cc: Pass args to 'xcrun clang' and zip dsym files.
+//
+// wrapped_clang passes its args to clang, but also supports a separate set of
+// invocations to generate dSYM files.  If "DSYM_HINT" flags are passed in, they
+// are used to construct that separate set of invocations (instead of being
+// passed to clang).
+// The following "DSYM_HINT" flags control dsym generation.  If any one if these
+// are passed in, then they all must be passed in.
+// "DSYM_HINT_LINKED_BINARY": Workspace-relative path to binary output of the
+//    link action generating the dsym file.
+// "DSYM_HINT_DSYM_PATH": Workspace-relative path to dSYM dwarf file.
+
+// FIGMA: This is copied from
+// https://github.com/bazelbuild/bazel/blob/5.2.0/tools/osx/crosstool/wrapped_clang.cc
+//
+// The only modifications are below marked FIGMA to read the paths to the
+// clang/clang++ executable from environment variables.
+
+#include <libgen.h>
+#include <spawn.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+extern char **environ;
+
+namespace {
+
+constexpr char kAddASTPathPrefix[] = "-Wl,-add_ast_path,";
+
+// Returns the base name of the given filepath. For example, given
+// /foo/bar/baz.txt, returns 'baz.txt'.
+const char *Basename(const char *filepath) {
+  const char *base = strrchr(filepath, '/');
+  return base ? (base + 1) : filepath;
+}
+
+// FIGMA: Returns the base name of the given filepath. For example, given
+// /foo/bar/baz.txt, returns '/foo/bar/'.
+std::string Dirname(const char *filepath) {
+  const char *base = strrchr(filepath, '/');
+  return base ? std::string(filepath, base - filepath) : filepath;
+}
+
+// Unescape and unquote an argument read from a line of a response file.
+static std::string Unescape(const std::string &arg) {
+  std::string result;
+  auto length = arg.size();
+  for (size_t i = 0; i < length; ++i) {
+    auto ch = arg[i];
+
+    // If it's a backslash, consume it and append the character that follows.
+    if (ch == '\\' && i + 1 < length) {
+      ++i;
+      result.push_back(arg[i]);
+      continue;
+    }
+
+    // If it's a quote, process everything up to the matching quote, unescaping
+    // backslashed characters as needed.
+    if (ch == '"' || ch == '\'') {
+      auto quote = ch;
+      ++i;
+      while (i != length && arg[i] != quote) {
+        if (arg[i] == '\\' && i + 1 < length) {
+          ++i;
+        }
+        result.push_back(arg[i]);
+        ++i;
+      }
+      if (i == length) {
+        break;
+      }
+      continue;
+    }
+
+    // It's a regular character.
+    result.push_back(ch);
+  }
+
+  return result;
+}
+
+// Converts an array of string arguments to char *arguments.
+// The first arg is reduced to its basename as per execve conventions.
+// Note that the lifetime of the char* arguments in the returned array
+// are controlled by the lifetime of the strings in args.
+std::vector<const char *> ConvertToCArgs(const std::vector<std::string> &args) {
+  std::vector<const char *> c_args;
+  c_args.push_back(Basename(args[0].c_str()));
+  for (int i = 1; i < args.size(); i++) {
+    c_args.push_back(args[i].c_str());
+  }
+  c_args.push_back(nullptr);
+  return c_args;
+}
+
+// Spawns a subprocess for given arguments args. The first argument is used
+// for the executable path.
+void RunSubProcess(const std::vector<std::string> &args) {
+  std::vector<const char *> exec_argv = ConvertToCArgs(args);
+  pid_t pid;
+  int status = posix_spawn(&pid, args[0].c_str(), nullptr, nullptr,
+                           const_cast<char **>(exec_argv.data()), environ);
+  if (status == 0) {
+    int wait_status;
+    do {
+      wait_status = waitpid(pid, &status, 0);
+    } while ((wait_status == -1) && (errno == EINTR));
+    if (wait_status < 0) {
+      std::cerr << "Error waiting on child process '" << args[0] << "'. "
+                << strerror(errno) << "\n";
+      abort();
+    }
+    if (WEXITSTATUS(status) != 0) {
+      std::cerr << "Error in child process '" << args[0] << "'. "
+                << WEXITSTATUS(status) << "\n";
+      abort();
+    }
+  } else {
+    std::cerr << "Error forking process '" << args[0] << "'. "
+              << strerror(status) << "\n";
+    abort();
+  }
+}
+
+// Finds and replaces all instances of oldsub with newsub, in-place on str.
+void FindAndReplace(const std::string &oldsub, const std::string &newsub,
+                    std::string *str) {
+  int start = 0;
+  while ((start = str->find(oldsub, start)) != std::string::npos) {
+    str->replace(start, oldsub.length(), newsub);
+    start += newsub.length();
+  }
+}
+
+// If arg is of the classic flag form "foo=bar", and flagname is 'foo', sets
+// str to point to a new std::string 'bar' and returns true.
+// Otherwise, returns false.
+bool SetArgIfFlagPresent(const std::string &arg, const std::string &flagname,
+                         std::string *str) {
+  std::string prefix_string = flagname + "=";
+  if (arg.compare(0, prefix_string.length(), prefix_string) == 0) {
+    *str = arg.substr(prefix_string.length());
+    return true;
+  }
+  return false;
+}
+
+// Returns the DEVELOPER_DIR environment variable in the current process
+// environment. Aborts if this variable is unset.
+std::string GetMandatoryEnvVar(const std::string &var_name) {
+  char *env_value = getenv(var_name.c_str());
+  if (env_value == nullptr) {
+    std::cerr << "Error: " << var_name << " not set.\n";
+    abort();
+  }
+  return env_value;
+}
+
+// Returns true if `str` starts with the specified `prefix`.
+bool StartsWith(const std::string &str, const std::string &prefix) {
+  return str.compare(0, prefix.size(), prefix) == 0;
+}
+
+// If *`str` begins `prefix`, strip it out and return true.
+// Otherwise leave *`str` unchanged and return false.
+bool StripPrefixStringIfPresent(std::string *str, const std::string &prefix) {
+  if (StartsWith(*str, prefix)) {
+    *str = str->substr(prefix.size());
+    return true;
+  }
+  return false;
+}
+
+// An RAII temporary file.
+class TempFile {
+ public:
+  // Create a new temporary file using the given path template string (the same
+  // form used by `mkstemp`). The file will automatically be deleted when the
+  // object goes out of scope.
+  static std::unique_ptr<TempFile> Create(const std::string &path_template) {
+    const char *tmpDir = getenv("TMPDIR");
+    if (!tmpDir) {
+      tmpDir = "/tmp";
+    }
+    size_t size = strlen(tmpDir) + path_template.size() + 2;
+    std::unique_ptr<char[]> path(new char[size]);
+    snprintf(path.get(), size, "%s/%s", tmpDir, path_template.c_str());
+
+    if (mkstemp(path.get()) == -1) {
+      std::cerr << "Failed to create temporary file '" << path.get()
+                << "': " << strerror(errno) << "\n";
+      return nullptr;
+    }
+    return std::unique_ptr<TempFile>(new TempFile(path.get()));
+  }
+
+  // Explicitly make TempFile non-copyable and movable.
+  TempFile(const TempFile &) = delete;
+  TempFile &operator=(const TempFile &) = delete;
+  TempFile(TempFile &&) = default;
+  TempFile &operator=(TempFile &&) = default;
+
+  ~TempFile() { remove(path_.c_str()); }
+
+  // Gets the path to the temporary file.
+  std::string GetPath() const { return path_; }
+
+ private:
+  explicit TempFile(const std::string &path) : path_(path) {}
+
+  std::string path_;
+};
+
+static std::unique_ptr<TempFile> WriteResponseFile(
+    const std::vector<std::string> &args) {
+  auto response_file = TempFile::Create("wrapped_clang_params.XXXXXX");
+  std::ofstream response_file_stream(response_file->GetPath());
+
+  for (const auto &arg : args) {
+    // When Clang/Swift write out a response file to communicate from driver to
+    // frontend, they just quote every argument to be safe; we duplicate that
+    // instead of trying to be "smarter" and only quoting when necessary.
+    response_file_stream << '"';
+    for (auto ch : arg) {
+      if (ch == '"' || ch == '\\') {
+        response_file_stream << '\\';
+      }
+      response_file_stream << ch;
+    }
+    response_file_stream << "\"\n";
+  }
+
+  response_file_stream.close();
+  return response_file;
+}
+
+void ProcessArgument(const std::string arg, const std::string developer_dir,
+                     const std::string sdk_root, const std::string cwd,
+                     bool relative_ast_path, std::string &linked_binary,
+                     std::string &dsym_path,
+                     std::function<void(const std::string &)> consumer);
+
+bool ProcessResponseFile(const std::string arg, const std::string developer_dir,
+                         const std::string sdk_root, const std::string cwd,
+                         bool relative_ast_path, std::string &linked_binary,
+                         std::string &dsym_path,
+                         std::function<void(const std::string &)> consumer) {
+  auto path = arg.substr(1);
+  std::ifstream original_file(path);
+  // Ignore non-file args such as '@loader_path/...'
+  if (!original_file.good()) {
+    return false;
+  }
+
+  std::string arg_from_file;
+  while (std::getline(original_file, arg_from_file)) {
+    // Arguments in response files might be quoted/escaped, so we need to
+    // unescape them ourselves.
+    ProcessArgument(Unescape(arg_from_file), developer_dir, sdk_root, cwd,
+                    relative_ast_path, linked_binary, dsym_path, consumer);
+  }
+
+  return true;
+}
+
+std::string GetCurrentDirectory() {
+  // Passing null,0 causes getcwd to allocate the buffer of the correct size.
+  char *buffer = getcwd(nullptr, 0);
+  std::string cwd(buffer);
+  free(buffer);
+  return cwd;
+}
+
+void ProcessArgument(const std::string arg, const std::string developer_dir,
+                     const std::string sdk_root, const std::string cwd,
+                     bool relative_ast_path, std::string &linked_binary,
+                     std::string &dsym_path,
+                     std::function<void(const std::string &)> consumer) {
+  auto new_arg = arg;
+  if (arg[0] == '@') {
+    if (ProcessResponseFile(arg, developer_dir, sdk_root, cwd,
+                            relative_ast_path, linked_binary, dsym_path,
+                            consumer)) {
+      return;
+    }
+  }
+
+  if (SetArgIfFlagPresent(arg, "DSYM_HINT_LINKED_BINARY", &linked_binary)) {
+    return;
+  }
+  if (SetArgIfFlagPresent(arg, "DSYM_HINT_DSYM_PATH", &dsym_path)) {
+    return;
+  }
+
+  std::string dest_dir, bitcode_symbol_map;
+  if (SetArgIfFlagPresent(arg, "DEBUG_PREFIX_MAP_PWD", &dest_dir)) {
+    new_arg = "-fdebug-prefix-map=" + cwd + "=" + dest_dir;
+  }
+  if (arg.compare("OSO_PREFIX_MAP_PWD") == 0) {
+    new_arg = "-Wl,-oso_prefix," + cwd + "/";
+  }
+
+  FindAndReplace("__BAZEL_XCODE_DEVELOPER_DIR__", developer_dir, &new_arg);
+  FindAndReplace("__BAZEL_XCODE_SDKROOT__", sdk_root, &new_arg);
+
+  // Make the `add_ast_path` options used to embed Swift module references
+  // absolute to enable Swift debugging without dSYMs: see
+  // https://forums.swift.org/t/improving-swift-lldb-support-for-path-remappings/22694
+  if (!relative_ast_path &&
+      StripPrefixStringIfPresent(&new_arg, kAddASTPathPrefix)) {
+    // Only modify relative paths.
+    if (!StartsWith(arg, "/")) {
+      new_arg = std::string(kAddASTPathPrefix) + cwd + "/" + new_arg;
+    } else {
+      new_arg = std::string(kAddASTPathPrefix) + new_arg;
+    }
+  }
+
+  consumer(new_arg);
+}
+
+}  // namespace
+
+int main(int argc, char *argv[]) {
+  std::string tool_name;
+
+  std::string binary_name = Basename(argv[0]);
+
+  // FIGMA: This is hack; sometimes the CWD has been changed to not be the
+  // sandbox exec root, so we won't be able to find CLANG_PATH since it is
+  // always relative to the exec root. We know that the `wrapped_clang` script
+  // is always at `external/llvm_toolchain/wrapped_clang`, so we can get back
+  // to the execroot by going up two directories.
+  std::string dirname = Dirname(argv[0]);
+  if (binary_name == "wrapped_clang_pp") {
+    tool_name = dirname + "/../../" + GetMandatoryEnvVar("CLANG_PP_PATH");
+  } else if (binary_name == "wrapped_clang") {
+    tool_name = dirname + "/../../" + GetMandatoryEnvVar("CLANG_PATH");
+  } else {
+    std::cerr << "Binary must either be named 'wrapped_clang' or "
+                 "'wrapped_clang_pp', not "
+              << binary_name << "\n";
+    abort();
+  }
+
+  std::string developer_dir = GetMandatoryEnvVar("DEVELOPER_DIR");
+  std::string sdk_root = GetMandatoryEnvVar("SDKROOT");
+  std::string linked_binary, dsym_path;
+
+  const std::string cwd = GetCurrentDirectory();
+  std::vector<std::string> invocation_args = {"/usr/bin/xcrun", tool_name};
+  std::vector<std::string> processed_args = {};
+
+  bool relative_ast_path = getenv("RELATIVE_AST_PATH") != nullptr;
+  auto consumer = [&](const std::string &arg) {
+    processed_args.push_back(arg);
+  };
+  for (int i = 1; i < argc; i++) {
+    std::string arg(argv[i]);
+
+    ProcessArgument(arg, developer_dir, sdk_root, cwd, relative_ast_path,
+                    linked_binary, dsym_path, consumer);
+  }
+
+  // Special mode that only prints the command. Used for testing.
+  if (getenv("__WRAPPED_CLANG_LOG_ONLY")) {
+    for (const std::string &arg : invocation_args) std::cout << arg << ' ';
+    for (const std::string &arg : processed_args) std::cout << arg << ' ';
+    std::cout << "\n";
+    return 0;
+  }
+
+  auto response_file = WriteResponseFile(processed_args);
+  invocation_args.push_back("@" + response_file->GetPath());
+
+  // Check to see if we should postprocess with dsymutil.
+  bool postprocess = false;
+  if ((!linked_binary.empty()) || (!dsym_path.empty())) {
+    if ((linked_binary.empty()) || (dsym_path.empty())) {
+      const char *missing_dsym_flag;
+      if (linked_binary.empty()) {
+        missing_dsym_flag = "DSYM_HINT_LINKED_BINARY";
+      } else {
+        missing_dsym_flag = "DSYM_HINT_DSYM_PATH";
+      }
+      std::cerr << "Error in clang wrapper: If any dsym "
+                   "hint is defined, then "
+                << missing_dsym_flag << " must be defined\n";
+      abort();
+    } else {
+      postprocess = true;
+    }
+  }
+
+  RunSubProcess(invocation_args);
+  if (!postprocess) {
+    return 0;
+  }
+
+  std::vector<std::string> dsymutil_args = {"/usr/bin/xcrun",
+                                            "dsymutil",
+                                            linked_binary,
+                                            "-o",
+                                            dsym_path,
+                                            "--flat",
+                                            "--no-swiftmodule-timestamp"};
+  RunSubProcess(dsymutil_args);
+  return 0;
+}


### PR DESCRIPTION
The first commit has already been reviewed as a patch in figma/figma. It includes the headers and libraries for clang plugins.

The second commit is new; it adds support for darwin arm64 builds to bazel-toolchain. Please read the commit message there for a lot more info.